### PR TITLE
Join meetings from the bar, and quiet down Google's non-events

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -340,14 +340,83 @@ function toggleHiddenCalendar(hidden, calendarId) {
   return next
 }
 
-function visibleEvents(events, hidden) {
+// Google's "I am working from home" markers arrive as all-day events, so
+// without this they eat a line of every single day while describing no
+// commitment at all.
+var NOISY_EVENT_TYPES = ["workingLocation"]
+
+function isNoisyEventType(event) {
+  var type = event && event.eventType
+  if (!type) return false
+  return NOISY_EVENT_TYPES.indexOf(String(type)) !== -1
+}
+
+function isDeclined(event) {
+  return !!event && String(event.responseStatus || "") === "declined"
+}
+
+function isOutOfOffice(event) {
+  return !!event && String(event.eventType || "") === "outOfOffice"
+}
+
+// Only https is ever launched. A meeting link is supplied by whoever sent the
+// invitation, so treating it as trusted input would be a mistake.
+function safeUrl(url) {
+  var text = String(url || "").trim()
+  if (text.indexOf("https://") !== 0) return ""
+  if (/[\s"'<>]/.test(text)) return ""
+  return text
+}
+
+function meetingUrlFor(event) {
+  return event ? safeUrl(event.meetingUrl) : ""
+}
+
+// The event's own page, used when there is nothing to join. Older files and
+// third-party writers have no such field, which is why this is never assumed.
+function eventUrlFor(event) {
+  return event ? safeUrl(event.eventUrl) : ""
+}
+
+// How long before the start, and after the end, a meeting still counts as
+// joinable. A Join button on next Tuesday's meeting is noise that dilutes the
+// one that matters, so the affordance only appears around the actual time.
+var JOIN_LEAD_MINUTES = 15
+var JOIN_GRACE_MINUTES = 15
+
+function isJoinableNow(event, nowMs, todayKey) {
+  if (!meetingUrlFor(event)) return false
+
+  // An all-day event has no useful clock window, so it stays joinable for the
+  // whole day it belongs to.
+  if (event.allDay) return event.dateKey === todayKey
+
+  var startMs = Date.parse(event.start)
+  var endMs = Date.parse(event.end)
+  if (isNaN(startMs)) return false
+  if (isNaN(endMs) || endMs < startMs) endMs = startMs
+
+  var opensAt = startMs - JOIN_LEAD_MINUTES * 60 * 1000
+  var closesAt = endMs + JOIN_GRACE_MINUTES * 60 * 1000
+  return nowMs >= opensAt && nowMs <= closesAt
+}
+
+// `options` is optional so older callers keep working: no options means only
+// the calendar filter applies, exactly as before.
+function visibleEvents(events, hidden, options) {
   if (!events || !events.length) return []
-  if (!hidden || !hidden.length) return events
+
+  var opts = options || {}
+  var dropNoisy = opts.hideWorkingLocation !== false
+  var dropDeclined = opts.hideDeclined === true
 
   var visible = []
   for (var i = 0; i < events.length; i++) {
-    if (isCalendarHidden(hidden, events[i].calendarId)) continue
-    visible.push(events[i])
+    var event = events[i]
+    if (isCalendarHidden(hidden, event.calendarId)) continue
+    if (dropNoisy && isNoisyEventType(event)) continue
+    if (dropDeclined && isDeclined(event)) continue
+    visible.push(event)
   }
   return visible
 }
@@ -521,6 +590,13 @@ if (typeof module !== "undefined") {
     isCalendarHidden: isCalendarHidden,
     toggleHiddenCalendar: toggleHiddenCalendar,
     visibleEvents: visibleEvents,
+    isNoisyEventType: isNoisyEventType,
+    isDeclined: isDeclined,
+    isOutOfOffice: isOutOfOffice,
+    safeUrl: safeUrl,
+    meetingUrlFor: meetingUrlFor,
+    eventUrlFor: eventUrlFor,
+    isJoinableNow: isJoinableNow,
     eventsForDateKey: eventsForDateKey,
     eventColors: eventColors,
     syncState: syncState

--- a/Panel.qml
+++ b/Panel.qml
@@ -124,7 +124,10 @@ Panel {
 
   function rebuildIndex() {
     var all = root.eventDoc ? root.eventDoc.events : []
-    root.visibleEventList = Model.visibleEvents(all, root.hiddenCalendars)
+    root.visibleEventList = Model.visibleEvents(all, root.hiddenCalendars, {
+      hideWorkingLocation: !root.showWorkingLocation,
+      hideDeclined: root.hideDeclined
+    })
     root.eventIndex = Model.indexEventsByDate(root.visibleEventList)
   }
 
@@ -138,6 +141,12 @@ Panel {
   // most people want in that slot is what is coming up next, not how much of
   // the year is gone.
   readonly property bool showYearProgress: setting("showYearProgress", false)
+
+  // Google's working-location markers arrive as all-day events and describe no
+  // commitment, so they are out by default. Declined invitations stay in by
+  // default: you probably still want to see what you said no to.
+  readonly property bool showWorkingLocation: setting("showWorkingLocation", false)
+  readonly property bool hideDeclined: setting("hideDeclined", false)
 
   // Hiding happens here rather than in the sync, so toggling a calendar back
   // on is instant instead of waiting for the next fetch. The sync keeps
@@ -170,7 +179,37 @@ Panel {
 
   property bool settingsOpen: false
 
+  function toggleWorkingLocation() {
+    persistSettings({ showWorkingLocation: !root.showWorkingLocation })
+  }
+
+  function toggleHideDeclined() {
+    persistSettings({ hideDeclined: !root.hideDeclined })
+  }
+
+  // Qt.openUrlExternally rather than the shell helper on purpose. That helper
+  // runs `bash -lc`, and a meeting link is supplied by whoever sent the
+  // invitation, so putting it through a shell would be a command injection.
+  // Model.safeUrl also refuses anything that is not plain https.
+  function openExternally(url) {
+    if (!url) return
+    Qt.openUrlExternally(url)
+    root.close()
+  }
+
+  function openMeeting(event) {
+    root.openExternally(Model.meetingUrlFor(event))
+  }
+
+  // Clicking the row opens the event itself. Joining is the button's job, so
+  // both actions stay reachable while a meeting is live.
+  function openEvent(event) {
+    root.openExternally(Model.eventUrlFor(event))
+  }
+
   onHiddenCalendarsChanged: root.rebuildIndex()
+  onShowWorkingLocationChanged: root.rebuildIndex()
+  onHideDeclinedChanged: root.rebuildIndex()
   onSettingsChanged: root.adoptSettings()
   Component.onCompleted: root.adoptSettings()
 
@@ -979,52 +1018,133 @@ Panel {
             Repeater {
               model: root.selectedEvents
 
-              Row {
+              // The hover wash lives on this wrapper, never inside the Row. A
+              // Row lays out every visible child, so an anchored background
+              // added as a Row child fights the layout and ejects the content.
+              Rectangle {
+                id: eventRow
                 required property var modelData
 
+                readonly property string meetingUrl: Model.meetingUrlFor(modelData)
+                readonly property bool declined: Model.isDeclined(modelData)
+                // Only around the actual time. A Join button on next week's
+                // meeting is noise that dilutes the one that matters.
+                readonly property bool joinable: Model.isJoinableNow(modelData, root.nowTick.getTime(), root.todayKey)
+                readonly property string eventUrl: Model.eventUrlFor(modelData)
+                readonly property bool openable: eventUrl !== ""
+
                 width: gridColumn.width
-                spacing: Style.space(4)
+                height: eventBody.height + Style.space(2)
+                radius: Style.cornerRadius
+                color: eventHover.hovered
+                  ? Qt.rgba(root.contentForeground.r, root.contentForeground.g,
+                            root.contentForeground.b, 0.08)
+                  : "transparent"
+
+                // Only rows that can actually do something respond to a click.
+                HoverHandler {
+                  id: eventHover
+                  enabled: eventRow.openable || eventRow.joinable
+                  cursorShape: Qt.PointingHandCursor
+                }
+
+                TapHandler {
+                  enabled: eventRow.openable
+                  onTapped: root.openEvent(eventRow.modelData)
+                }
+
+                Rectangle {
+                  id: joinButton
+                  visible: eventRow.joinable
+                  anchors.right: parent.right
+                  anchors.verticalCenter: parent.verticalCenter
+                  width: joinLabel.implicitWidth + Style.space(8)
+                  height: joinLabel.implicitHeight + Style.space(3)
+                  radius: height / 2
+                  color: eventHover.hovered
+                    ? Style.selectedStateColor(root.contentForeground, Color.accent)
+                    : "transparent"
+                  border.width: Style.spacing.hairline
+                  border.color: eventHover.hovered
+                    ? "transparent"
+                    : Qt.darker(root.contentForeground, 2.0)
+
+                  // Its own handler, declared on the button, so the grab
+                  // happens here and the row's opener does not also fire.
+                  TapHandler {
+                    gesturePolicy: TapHandler.ReleaseWithinBounds
+                    onTapped: root.openMeeting(eventRow.modelData)
+                  }
+
+                  Text {
+                    id: joinLabel
+                    anchors.centerIn: parent
+                    text: qsTr("Join")
+                    color: eventHover.hovered ? Color.background : Qt.darker(root.contentForeground, 1.4)
+                    font.family: root.contentFontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+                }
+
+                Row {
+                  id: eventBody
+                  anchors.left: parent.left
+                  anchors.right: eventRow.joinable ? joinButton.left : parent.right
+                  anchors.rightMargin: eventRow.joinable ? Style.space(3) : 0
+                  anchors.verticalCenter: parent.verticalCenter
+                  spacing: Style.space(4)
 
                 Rectangle {
                   width: Style.space(2)
                   height: eventLines.height
                   radius: width / 2
-                  color: modelData.color
+                  color: eventRow.declined
+                    ? Qt.darker(eventRow.modelData.color, 2.2)
+                    : eventRow.modelData.color
                 }
 
                 Text {
                   width: Style.space(44)
-                  text: modelData.allDay
+                  text: eventRow.modelData.allDay
                     ? qsTr("All day")
-                    : Qt.formatDateTime(new Date(modelData.start), "HH:mm")
-                  color: Qt.darker(root.contentForeground, 1.5)
+                    : Qt.formatDateTime(new Date(eventRow.modelData.start), "HH:mm")
+                  color: Qt.darker(root.contentForeground, eventRow.declined ? 2.2 : 1.5)
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
+                  font.strikeout: eventRow.declined
                 }
 
                 Column {
                   id: eventLines
-                  width: parent.width - Style.space(54)
+                  width: eventBody.width - Style.space(54)
                   spacing: Style.space(1)
 
                   Text {
                     width: parent.width
-                    text: modelData.title
-                    color: root.contentForeground
+                    text: eventRow.modelData.title
+                    color: eventRow.declined
+                      ? Qt.darker(root.contentForeground, 2.0)
+                      : root.contentForeground
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.bodySmall
+                    font.strikeout: eventRow.declined
                     elide: Text.ElideRight
                   }
 
                   Text {
                     width: parent.width
-                    visible: modelData.location !== ""
-                    text: modelData.location
+                    visible: text !== ""
+                    text: {
+                      if (eventRow.declined) return qsTr("Declined")
+                      if (Model.isOutOfOffice(eventRow.modelData)) return qsTr("Out of office")
+                      return eventRow.modelData.location
+                    }
                     color: Qt.darker(root.contentForeground, 1.9)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
                     elide: Text.ElideRight
                   }
+                }
                 }
               }
             }
@@ -1063,6 +1183,8 @@ Panel {
             calendars: root.knownCalendars
             hiddenCalendars: root.hiddenCalendars
             showYearProgress: root.showYearProgress
+            showWorkingLocation: root.showWorkingLocation
+            hideDeclined: root.hideDeclined
             weekStartsMonday: root.weekStart === 1
             announceLeadMinutes: root.setting("announceLeadMinutes", 15)
 
@@ -1075,6 +1197,8 @@ Panel {
 
             onCalendarToggled: function(calendarId) { root.toggleCalendar(calendarId) }
             onYearProgressToggled: root.toggleYearProgress()
+            onWorkingLocationToggled: root.toggleWorkingLocation()
+            onHideDeclinedToggled: root.toggleHideDeclined()
             onWeekStartToggled: root.toggleWeekStart()
             onLeadMinutesPicked: function(minutes) { root.setAnnounceLeadMinutes(minutes) }
           }

--- a/Panel.qml
+++ b/Panel.qml
@@ -1048,11 +1048,6 @@ Panel {
                   cursorShape: Qt.PointingHandCursor
                 }
 
-                TapHandler {
-                  enabled: eventRow.openable
-                  onTapped: root.openEvent(eventRow.modelData)
-                }
-
                 Rectangle {
                   id: joinButton
                   visible: eventRow.joinable
@@ -1061,13 +1056,18 @@ Panel {
                   width: joinLabel.implicitWidth + Style.space(8)
                   height: joinLabel.implicitHeight + Style.space(3)
                   radius: height / 2
-                  color: eventHover.hovered
+                  color: joinHover.hovered
                     ? Style.selectedStateColor(root.contentForeground, Color.accent)
                     : "transparent"
                   border.width: Style.spacing.hairline
-                  border.color: eventHover.hovered
+                  border.color: joinHover.hovered
                     ? "transparent"
                     : Qt.darker(root.contentForeground, 2.0)
+
+                  HoverHandler {
+                    id: joinHover
+                    cursorShape: Qt.PointingHandCursor
+                  }
 
                   // Its own handler, declared on the button, so the grab
                   // happens here and the row's opener does not also fire.
@@ -1080,7 +1080,7 @@ Panel {
                     id: joinLabel
                     anchors.centerIn: parent
                     text: qsTr("Join")
-                    color: eventHover.hovered ? Color.background : Qt.darker(root.contentForeground, 1.4)
+                    color: joinHover.hovered ? Color.background : Qt.darker(root.contentForeground, 1.4)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
                   }
@@ -1093,6 +1093,15 @@ Panel {
                   anchors.rightMargin: eventRow.joinable ? Style.space(3) : 0
                   anchors.verticalCenter: parent.verticalCenter
                   spacing: Style.space(4)
+
+                  // Deliberately here and not on the row: this stops at the
+                  // Join button's left edge, so the two hit areas cannot
+                  // overlap. Two TapHandlers over one point would both fire
+                  // and open two tabs.
+                  TapHandler {
+                    enabled: eventRow.openable
+                    onTapped: root.openEvent(eventRow.modelData)
+                  }
 
                 Rectangle {
                   width: Style.space(2)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Click the clock, then the gear icon in the panel header.
 | Calendars | Show or hide each calendar. The list comes from your own events, so it needs no configuration |
 | Week starts on Monday | Off starts the week on Sunday |
 | Working location events | Google's work-from-home markers. Hidden by default because they are all-day rows describing no commitment |
-| Hide declined invitations | Off keeps them listed and struck through |
+| Declined invitations | On lists them struck through, off hides them entirely |
 | Year and life progress | Brings back the built-in clock's bars, off by default |
 | Bar label | How early the bar announces what is next: never, 5, 15, 30 or 60 minutes |
 | Sync | Event count, source and last sync time, for diagnosing a quiet calendar |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ time away for an event title would be a downgrade you pay for all day.
 - The selected day's agenda under the grid, click any day to see it
 - The next event today, with a live countdown, in the panel header
 - The bar label announces what is next, minutes before it starts
+- A **Join** button on meetings that have a video link, shown only from 15
+  minutes before the start until 15 minutes after the end
+- Clicking any event opens it in your calendar
 - Per-calendar visibility, week start, and countdown lead time in a settings page
+- Google's working-location markers hidden by default, declined invitations
+  struck through
 - Everything the built-in Omarchy clock does: label formats, right click to
   cycle them, the year and life progress bars if you want them back
 - Theme aware, because it is a fork of the built-in clock
@@ -138,6 +143,15 @@ a shell script, a cron job of your own. No credentials, no network, no `gws`.
 }
 ```
 
+These four extra fields are optional. Omit them and everything still works:
+
+| Field | Effect |
+|---|---|
+| `meetingUrl` | Shows the **Join** button around the event's time. Must be `https`, anything else is dropped |
+| `eventUrl` | Clicking the row opens this. Must be `https` |
+| `eventType` | `workingLocation` is hidden by default, `outOfOffice` is labelled |
+| `responseStatus` | `declined` is struck through, and can be hidden entirely |
+
 Rules a writer has to follow:
 
 - `dateKey` is `YYYY-MM-DD` in local time, and it is what the grid keys on.
@@ -161,6 +175,8 @@ Click the clock, then the gear icon in the panel header.
 |---|---|
 | Calendars | Show or hide each calendar. The list comes from your own events, so it needs no configuration |
 | Week starts on Monday | Off starts the week on Sunday |
+| Working location events | Google's work-from-home markers. Hidden by default because they are all-day rows describing no commitment |
+| Hide declined invitations | Off keeps them listed and struck through |
 | Year and life progress | Brings back the built-in clock's bars, off by default |
 | Bar label | How early the bar announces what is next: never, 5, 15, 30 or 60 minutes |
 | Sync | Event count, source and last sync time, for diagnosing a quiet calendar |
@@ -199,6 +215,8 @@ systemctl --user list-timers omarchy-calendar-sync.timer
 | The panel says the calendar may be out of date | The file exists but `syncedAt` is old. Check the journal above |
 | An event shows up twice | Two of your calendars both carry it. Hide one in settings. The sync already drops exact duplicates by iCalUID and start time |
 | `The project ID you specified is already in use` during setup | Fixed in 0.1.1. Google Cloud project ids are unique across all of Google, and older versions hardcoded one. Update the plugin, or pass your own: `PROJECT_ID=something-unique sync/setup` |
+| Clicking an event opens your calendar but not the event | The link resolves only for the Google account the sync authenticated as. If your browser opens it in a profile signed into a different account, Google falls back to the calendar root. Route `google.com/calendar` to the profile holding that account |
+| The Join button never appears | It only shows from 15 minutes before the start until 15 minutes after the end, and only when the event has a video link |
 | Events are off by a day | Report it. Timezone handling resolves a named IANA zone precisely to avoid this, and there is a regression test for daylight saving transitions |
 
 ## Uninstall

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -18,6 +18,8 @@ Column {
   property var hiddenCalendars: []
   property bool showYearProgress: false
   property bool weekStartsMonday: true
+  property bool showWorkingLocation: false
+  property bool hideDeclined: false
   property int announceLeadMinutes: 15
 
   property string syncedAt: ""
@@ -28,6 +30,8 @@ Column {
   signal calendarToggled(string calendarId)
   signal yearProgressToggled()
   signal weekStartToggled()
+  signal workingLocationToggled()
+  signal hideDeclinedToggled()
   signal leadMinutesPicked(int minutes)
 
   readonly property color muted: Qt.darker(foreground, 1.5)
@@ -157,6 +161,20 @@ Column {
     hint: qsTr("Off starts the week on Sunday")
     checked: root.weekStartsMonday
     onActivated: root.weekStartToggled()
+  }
+
+  ToggleRow {
+    label: qsTr("Working location events")
+    hint: qsTr("Google's work-from-home markers, hidden by default")
+    checked: root.showWorkingLocation
+    onActivated: root.workingLocationToggled()
+  }
+
+  ToggleRow {
+    label: qsTr("Hide declined invitations")
+    hint: qsTr("Off keeps them listed, struck through")
+    checked: root.hideDeclined
+    onActivated: root.hideDeclinedToggled()
   }
 
   ToggleRow {

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -171,9 +171,11 @@ Column {
   }
 
   ToggleRow {
-    label: qsTr("Hide declined invitations")
-    hint: qsTr("Off keeps them listed, struck through")
-    checked: root.hideDeclined
+    // Every row on this page reads "checked means shown". Phrasing this one as
+    // "Hide ..." inverted that and made the page contradict itself.
+    label: qsTr("Declined invitations")
+    hint: qsTr("Shown struck through when on")
+    checked: !root.hideDeclined
     onActivated: root.hideDeclinedToggled()
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "tmn73.calendar",
   "name": "Calendar",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "tmn73",
   "description": "Your Google Calendar in the bar, with a month view and a countdown to what is next",
   "kinds": [

--- a/sync/omarchy_calendar_sync/contract.py
+++ b/sync/omarchy_calendar_sync/contract.py
@@ -24,8 +24,23 @@ EVENT_FIELDS = (
     "location",
 )
 
+# Deliberately optional. The README promises that anything able to write this
+# file works, so khal, vdirsyncer and hand-rolled scripts are consumers of this
+# schema. Making a new field required would break every one of them on upgrade.
+# Validated for type when present, never demanded.
+OPTIONAL_EVENT_FIELDS = (
+    "meetingUrl",
+    "eventUrl",
+    "eventType",
+    "responseStatus",
+)
+
 _DATE_KEY = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+# https only. Meeting links arrive from whoever sent the invitation, so the
+# widget must never be handed a scheme it would be unwise to launch.
+_HTTPS_URL = re.compile(r"^https://[^\s]+$")
 
 
 def build_document(events, synced_at, source):
@@ -89,5 +104,14 @@ def _validate_event(index, event):
     for field in ("id", "calendarId", "calendarName", "start", "end", "title"):
         if field in event and not isinstance(event[field], str):
             problems.append(f"{where}.{field} must be a string")
+
+    for field in OPTIONAL_EVENT_FIELDS:
+        if field in event and not isinstance(event[field], str):
+            problems.append(f"{where}.{field} must be a string when present")
+
+    for field in ("meetingUrl", "eventUrl"):
+        value = event.get(field)
+        if isinstance(value, str) and value and not _HTTPS_URL.match(value):
+            problems.append(f"{where}.{field} must be an https URL")
 
     return problems

--- a/sync/omarchy_calendar_sync/contract.py
+++ b/sync/omarchy_calendar_sync/contract.py
@@ -40,7 +40,8 @@ _COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 # https only. Meeting links arrive from whoever sent the invitation, so the
 # widget must never be handed a scheme it would be unwise to launch.
-_HTTPS_URL = re.compile(r"^https://[^\s]+$")
+# Kept in step with normalize._https_only and Model.safeUrl.
+_HTTPS_URL = re.compile(r"^https://[^\s\"'<>]+$")
 
 
 def build_document(events, synced_at, source):

--- a/sync/omarchy_calendar_sync/normalize.py
+++ b/sync/omarchy_calendar_sync/normalize.py
@@ -10,6 +10,43 @@ from datetime import date, datetime, time, timedelta
 NO_TITLE = "(no title)"
 
 
+def _https_only(value):
+    """Keep a URL only if it is https.
+
+    Meeting links come from whoever sent the invitation, not from the user, so
+    anything else is dropped rather than handed to the widget to launch.
+    """
+    text = str(value or "").strip()
+    return text if text.startswith("https://") and " " not in text else ""
+
+
+def _meeting_url(gevent):
+    """The video link for an event, preferring the one Google resolves itself."""
+    direct = _https_only(gevent.get("hangoutLink"))
+    if direct:
+        return direct
+
+    conference = gevent.get("conferenceData") or {}
+    for entry in conference.get("entryPoints") or []:
+        if entry.get("entryPointType") == "video":
+            found = _https_only(entry.get("uri"))
+            if found:
+                return found
+    return ""
+
+
+def _response_status(gevent):
+    """The user's own answer to the invitation, blank when not invited.
+
+    Google marks the user's own row in `attendees` with self: true. An event
+    the user created alone has no attendees at all.
+    """
+    for attendee in gevent.get("attendees") or []:
+        if attendee.get("self"):
+            return str(attendee.get("responseStatus") or "")
+    return ""
+
+
 def normalize_all(gevents, calendar, tz):
     """Normalize a list of Google events, flattening the per-day rows."""
     rows = []
@@ -52,6 +89,11 @@ def normalize_event(gevent, calendar, tz):
     start_iso = start_dt.isoformat()
     end_iso = end_dt.isoformat()
 
+    meeting_url = _meeting_url(gevent)
+    event_url = _https_only(gevent.get("htmlLink"))
+    event_type = str(gevent.get("eventType") or "")
+    response_status = _response_status(gevent)
+
     return [
         {
             "id": gevent.get("id", ""),
@@ -64,6 +106,10 @@ def normalize_event(gevent, calendar, tz):
             "allDay": all_day,
             "title": title,
             "location": location,
+            "meetingUrl": meeting_url,
+            "eventUrl": event_url,
+            "eventType": event_type,
+            "responseStatus": response_status,
         }
         for day in _covered_days(start_dt, end_dt, all_day)
     ]

--- a/sync/omarchy_calendar_sync/normalize.py
+++ b/sync/omarchy_calendar_sync/normalize.py
@@ -17,7 +17,14 @@ def _https_only(value):
     anything else is dropped rather than handed to the widget to launch.
     """
     text = str(value or "").strip()
-    return text if text.startswith("https://") and " " not in text else ""
+    if not text.startswith("https://"):
+        return ""
+    # Must match Model.safeUrl exactly. When the widget is stricter than the
+    # sync, a URL is written, then silently refused, and there is nothing to
+    # debug: no button, no error.
+    if any(char in text for char in ' \t\n"\'<>'):
+        return ""
+    return text
 
 
 def _meeting_url(gevent):

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -278,3 +278,122 @@ test('truncateTitle does not leave a dangling space before the ellipsis', () => 
 test('truncateTitle tolerates null', () => {
   assert.equal(Model.truncateTitle(null, 10), '')
 })
+
+const TYPED = [
+  { id: 'a', calendarId: 'w', dateKey: '2026-08-10', eventType: 'default', responseStatus: 'accepted' },
+  { id: 'b', calendarId: 'w', dateKey: '2026-08-10', eventType: 'workingLocation', responseStatus: '' },
+  { id: 'c', calendarId: 'w', dateKey: '2026-08-10', eventType: 'default', responseStatus: 'declined' },
+  { id: 'd', calendarId: 'w', dateKey: '2026-08-10', eventType: 'outOfOffice', responseStatus: '' }
+]
+
+test('visibleEvents hides workingLocation by default', () => {
+  const ids = Model.visibleEvents(TYPED, []).map(e => e.id)
+  assert.deepEqual(ids, ['a', 'c', 'd'])
+})
+
+test('visibleEvents can show workingLocation when asked', () => {
+  const ids = Model.visibleEvents(TYPED, [], { hideWorkingLocation: false }).map(e => e.id)
+  assert.deepEqual(ids, ['a', 'b', 'c', 'd'])
+})
+
+test('visibleEvents hides declined only when asked', () => {
+  assert.deepEqual(Model.visibleEvents(TYPED, [], { hideDeclined: true }).map(e => e.id), ['a', 'd'])
+  assert.deepEqual(Model.visibleEvents(TYPED, [], { hideDeclined: false }).map(e => e.id), ['a', 'c', 'd'])
+})
+
+test('visibleEvents still applies the calendar filter alongside type filters', () => {
+  assert.deepEqual(Model.visibleEvents(TYPED, ['w']).map(e => e.id), [])
+})
+
+test('visibleEvents with no options behaves as the old two-argument call', () => {
+  const plain = [{ id: 'x', calendarId: 'w', dateKey: '2026-08-10' }]
+  assert.deepEqual(Model.visibleEvents(plain, []).map(e => e.id), ['x'])
+})
+
+test('isDeclined and isOutOfOffice read the right fields', () => {
+  assert.equal(Model.isDeclined(TYPED[2]), true)
+  assert.equal(Model.isDeclined(TYPED[0]), false)
+  assert.equal(Model.isDeclined(null), false)
+  assert.equal(Model.isOutOfOffice(TYPED[3]), true)
+  assert.equal(Model.isOutOfOffice(TYPED[0]), false)
+})
+
+test('safeUrl only lets https through', () => {
+  assert.equal(Model.safeUrl('https://meet.google.com/abc'), 'https://meet.google.com/abc')
+  assert.equal(Model.safeUrl('http://meet.google.com/abc'), '')
+  assert.equal(Model.safeUrl('javascript:alert(1)'), '')
+  assert.equal(Model.safeUrl('file:///etc/passwd'), '')
+  assert.equal(Model.safeUrl(''), '')
+  assert.equal(Model.safeUrl(null), '')
+})
+
+test('safeUrl rejects anything that could break out of an argument', () => {
+  assert.equal(Model.safeUrl('https://ok.com; rm -rf ~'), '')
+  assert.equal(Model.safeUrl('https://ok.com "quoted"'), '')
+  assert.equal(Model.safeUrl("https://ok.com'x"), '')
+  assert.equal(Model.safeUrl('https://ok.com<script>'), '')
+})
+
+test('meetingUrlFor is empty rather than undefined when absent', () => {
+  assert.equal(Model.meetingUrlFor({ id: 'x' }), '')
+  assert.equal(Model.meetingUrlFor(null), '')
+  assert.equal(Model.meetingUrlFor({ meetingUrl: 'https://z.com/1' }), 'https://z.com/1')
+})
+
+const meeting = (start, end, extra = {}) => ({
+  id: 's', title: 'Standup', allDay: false, dateKey: '2026-08-10',
+  start, end, meetingUrl: 'https://meet.google.com/x', ...extra
+})
+const TKEY = '2026-08-10'
+
+test('isJoinableNow opens 15 minutes before the start', () => {
+  const e = meeting('2026-08-10T09:00:00-05:00', '2026-08-10T09:30:00-05:00')
+  const at = t => Model.isJoinableNow(e, Date.parse(t), TKEY)
+  assert.equal(at('2026-08-10T08:44:00-05:00'), false)
+  assert.equal(at('2026-08-10T08:45:00-05:00'), true)
+})
+
+test('isJoinableNow stays open during the meeting', () => {
+  const e = meeting('2026-08-10T09:00:00-05:00', '2026-08-10T09:30:00-05:00')
+  assert.equal(Model.isJoinableNow(e, Date.parse('2026-08-10T09:15:00-05:00'), TKEY), true)
+})
+
+test('isJoinableNow keeps a 15 minute grace after the end', () => {
+  const e = meeting('2026-08-10T09:00:00-05:00', '2026-08-10T09:30:00-05:00')
+  const at = t => Model.isJoinableNow(e, Date.parse(t), TKEY)
+  assert.equal(at('2026-08-10T09:45:00-05:00'), true)
+  assert.equal(at('2026-08-10T09:46:00-05:00'), false)
+})
+
+test('isJoinableNow is false for a meeting on another day', () => {
+  const e = meeting('2026-08-14T09:00:00-05:00', '2026-08-14T09:30:00-05:00')
+  assert.equal(Model.isJoinableNow(e, Date.parse('2026-08-10T09:00:00-05:00'), TKEY), false)
+})
+
+test('isJoinableNow needs a usable link', () => {
+  const noLink = meeting('2026-08-10T09:00:00-05:00', '2026-08-10T09:30:00-05:00', { meetingUrl: '' })
+  const bad = meeting('2026-08-10T09:00:00-05:00', '2026-08-10T09:30:00-05:00', { meetingUrl: 'javascript:x' })
+  const now = Date.parse('2026-08-10T09:05:00-05:00')
+  assert.equal(Model.isJoinableNow(noLink, now, TKEY), false)
+  assert.equal(Model.isJoinableNow(bad, now, TKEY), false)
+})
+
+test('isJoinableNow treats an all-day event as joinable for its whole day', () => {
+  const e = meeting('2026-08-10T00:00:00-05:00', '2026-08-11T00:00:00-05:00', { allDay: true })
+  assert.equal(Model.isJoinableNow(e, Date.parse('2026-08-10T20:00:00-05:00'), TKEY), true)
+  assert.equal(Model.isJoinableNow(e, Date.parse('2026-08-10T20:00:00-05:00'), '2026-08-11'), false)
+})
+
+test('isJoinableNow survives an unreadable or inverted time range', () => {
+  const bad = meeting('nope', 'nope')
+  assert.equal(Model.isJoinableNow(bad, Date.parse('2026-08-10T09:00:00-05:00'), TKEY), false)
+  const inverted = meeting('2026-08-10T09:00:00-05:00', '2026-08-10T08:00:00-05:00')
+  assert.equal(Model.isJoinableNow(inverted, Date.parse('2026-08-10T09:05:00-05:00'), TKEY), true)
+})
+
+test('eventUrlFor mirrors meetingUrlFor and is https only', () => {
+  assert.equal(Model.eventUrlFor({ eventUrl: 'https://calendar.google.com/e' }), 'https://calendar.google.com/e')
+  assert.equal(Model.eventUrlFor({ eventUrl: 'http://calendar.google.com/e' }), '')
+  assert.equal(Model.eventUrlFor({}), '')
+  assert.equal(Model.eventUrlFor(null), '')
+})

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -57,3 +57,33 @@ class TestBuildDocument(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestOptionalFields(unittest.TestCase):
+    def load(self):
+        return json.loads((FIXTURES / "calendar-events.json").read_text())
+
+    def test_a_document_without_the_optional_fields_is_still_valid(self):
+        # Third-party writers predate these fields. Upgrading must not break them.
+        doc = self.load()
+        for event in doc["events"]:
+            for field in contract.OPTIONAL_EVENT_FIELDS:
+                event.pop(field, None)
+        self.assertEqual(contract.validate(doc), [])
+
+    def test_optional_fields_are_type_checked_when_present(self):
+        doc = self.load()
+        doc["events"][0]["eventType"] = 42
+        problems = contract.validate(doc)
+        self.assertTrue(any("eventType" in p for p in problems))
+
+    def test_a_non_https_meeting_url_is_rejected(self):
+        doc = self.load()
+        doc["events"][0]["meetingUrl"] = "javascript:alert(1)"
+        problems = contract.validate(doc)
+        self.assertTrue(any("meetingUrl" in p for p in problems))
+
+    def test_an_empty_meeting_url_is_accepted(self):
+        doc = self.load()
+        doc["events"][0]["meetingUrl"] = ""
+        self.assertEqual(contract.validate(doc), [])

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -246,3 +246,30 @@ class TestEventTypeAndResponse(unittest.TestCase):
         rows = normalize.normalize_event(event, CAL, BOGOTA)
         self.assertEqual(len(rows), 2)
         self.assertTrue(all(r["meetingUrl"] == "https://meet.google.com/x" for r in rows))
+
+
+class TestUrlGuardMatchesTheWidget(unittest.TestCase):
+    """The widget's Model.safeUrl rejects quotes and angle brackets.
+
+    A sync that is more permissive writes a URL the widget then silently
+    refuses, which shows up as a missing button and nothing else.
+    """
+
+    def test_quotes_and_angle_brackets_are_refused(self):
+        for hostile in (
+            'https://ok.example.com/"x',
+            "https://ok.example.com/'x",
+            "https://ok.example.com/<x",
+            "https://ok.example.com/>x",
+            "https://ok.example.com/\tx",
+        ):
+            event = timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00")
+            event["hangoutLink"] = hostile
+            rows = normalize.normalize_event(event, CAL, BOGOTA)
+            self.assertEqual(rows[0]["meetingUrl"], "", hostile)
+
+    def test_an_ordinary_link_still_passes(self):
+        event = timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00")
+        event["hangoutLink"] = "https://meet.google.com/abc-defg-hij?authuser=1"
+        rows = normalize.normalize_event(event, CAL, BOGOTA)
+        self.assertEqual(rows[0]["meetingUrl"], "https://meet.google.com/abc-defg-hij?authuser=1")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -176,3 +176,73 @@ class TestNormalizeAll(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestMeetingUrl(unittest.TestCase):
+    def test_hangout_link_is_used(self):
+        event = timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00")
+        event["hangoutLink"] = "https://meet.google.com/abc-defg-hij"
+        rows = normalize.normalize_event(event, CAL, BOGOTA)
+        self.assertEqual(rows[0]["meetingUrl"], "https://meet.google.com/abc-defg-hij")
+
+    def test_conference_data_video_entry_is_used_when_no_hangout_link(self):
+        event = timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00")
+        event["conferenceData"] = {
+            "entryPoints": [
+                {"entryPointType": "phone", "uri": "tel:+15551234"},
+                {"entryPointType": "video", "uri": "https://zoom.us/j/123"},
+            ]
+        }
+        rows = normalize.normalize_event(event, CAL, BOGOTA)
+        self.assertEqual(rows[0]["meetingUrl"], "https://zoom.us/j/123")
+
+    def test_non_https_schemes_are_dropped(self):
+        # A meeting link comes from whoever sent the invitation, so anything
+        # the widget should not launch must never reach it.
+        for hostile in (
+            "http://meet.example.com/x",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "https://ok.example.com; rm -rf ~",
+        ):
+            event = timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00")
+            event["hangoutLink"] = hostile
+            rows = normalize.normalize_event(event, CAL, BOGOTA)
+            self.assertEqual(rows[0]["meetingUrl"], "", hostile)
+
+    def test_missing_link_is_an_empty_string_not_none(self):
+        rows = normalize.normalize_event(
+            timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00"), CAL, BOGOTA
+        )
+        self.assertEqual(rows[0]["meetingUrl"], "")
+        self.assertEqual(rows[0]["eventUrl"], "")
+
+
+class TestEventTypeAndResponse(unittest.TestCase):
+    def test_event_type_is_carried(self):
+        event = timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00")
+        event["eventType"] = "workingLocation"
+        rows = normalize.normalize_event(event, CAL, BOGOTA)
+        self.assertEqual(rows[0]["eventType"], "workingLocation")
+
+    def test_own_response_status_is_picked_from_attendees(self):
+        event = timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00")
+        event["attendees"] = [
+            {"email": "someone@example.com", "responseStatus": "accepted"},
+            {"email": "me@example.com", "self": True, "responseStatus": "declined"},
+        ]
+        rows = normalize.normalize_event(event, CAL, BOGOTA)
+        self.assertEqual(rows[0]["responseStatus"], "declined")
+
+    def test_no_attendees_means_no_response_status(self):
+        rows = normalize.normalize_event(
+            timed("2026-08-10T09:00:00-05:00", "2026-08-10T09:15:00-05:00"), CAL, BOGOTA
+        )
+        self.assertEqual(rows[0]["responseStatus"], "")
+
+    def test_every_row_of_a_multi_day_event_carries_the_extras(self):
+        event = timed("2026-08-10T23:00:00-05:00", "2026-08-11T01:00:00-05:00")
+        event["hangoutLink"] = "https://meet.google.com/x"
+        rows = normalize.normalize_event(event, CAL, BOGOTA)
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(all(r["meetingUrl"] == "https://meet.google.com/x" for r in rows))


### PR DESCRIPTION
## Why

The sync already fetched a video link for 93 of my 219 events and threw it away. The bar would tell me a meeting starts in two minutes while I went looking for the tab.

## What's new

- **Join button** on events with a video link, shown only from 15 minutes before the start until 15 minutes after the end. A button on next week's meeting is noise that dilutes the one that matters.
- **Clicking a row opens the event** in your calendar. The button keeps its own tap handler so both actions stay reachable while a meeting is live.
- **`workingLocation` events hidden by default.** Google's work-from-home markers arrive as all-day rows describing no commitment, so they ate a line of every single day. 6 of my last 48 events were these.
- **Declined invitations struck through**, and hideable entirely.
- Two new settings rows for the above.

## Contract change

Four new fields: `meetingUrl`, `eventUrl`, `eventType`, `responseStatus`. All **optional**. The README promises anything can write this file, so making them required would break khal, vdirsyncer and every hand-rolled script on upgrade. They're type-checked when present and never demanded.

## Security

URLs are validated as `https` in both the sync and the widget, and opened with `Qt.openUrlExternally`, not the shell helper. That helper runs `bash -lc`, and a meeting link comes from whoever sent the invitation, so putting it through a shell would be a command injection. There are tests asserting `javascript:`, `file://` and `https://ok.com; rm -rf ~` never survive.

## Tests

102 Python, 61 Node. New coverage on the join window boundaries, the URL filtering, the type filters, and that a document without any of the new fields still validates.
