### PR TITLE
Tell people how to connect a calendar, and let them copy the command

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -368,6 +368,17 @@ function safeUrl(url) {
   return text
 }
 
+// Turn the QML file URL of a bundled script into something a person can paste.
+// Derived rather than hardcoded: `omarchy plugin add` uses the manifest id, but
+// a hand-cloned checkout can live anywhere, and a wrong path in the one message
+// a new user sees is worse than no message.
+function commandPathFromUrl(fileUrl, home) {
+  var text = String(fileUrl || "")
+  if (text.indexOf("file://") === 0) text = text.substring(7)
+  if (home && text.indexOf(home + "/") === 0) text = "~" + text.substring(home.length)
+  return text
+}
+
 function meetingUrlFor(event) {
   return event ? safeUrl(event.meetingUrl) : ""
 }
@@ -594,6 +605,7 @@ if (typeof module !== "undefined") {
     isDeclined: isDeclined,
     isOutOfOffice: isOutOfOffice,
     safeUrl: safeUrl,
+    commandPathFromUrl: commandPathFromUrl,
     meetingUrlFor: meetingUrlFor,
     eventUrlFor: eventUrlFor,
     isJoinableNow: isJoinableNow,

--- a/Panel.qml
+++ b/Panel.qml
@@ -79,6 +79,13 @@ Panel {
   // Matches the sync timer's interval. Model.syncState allows four of these
   // to elapse before calling the file stale, so one missed run stays quiet.
   readonly property int syncIntervalSeconds: 300
+
+  // Spelled out in full because the people who need it are the ones who
+  // installed from the marketplace listing and never opened the README.
+  // Resolved from this file's own location, so it is right whether the plugin
+  // was installed by `omarchy plugin add` or cloned somewhere by hand.
+  readonly property string setupCommand: Model.commandPathFromUrl(
+    Qt.resolvedUrl("sync/setup"), Quickshell.env("HOME") || "")
   readonly property string syncState: eventVersionMismatch
     ? "version"
     : Model.syncState(eventDoc, Date.now(), syncIntervalSeconds)
@@ -377,6 +384,27 @@ Panel {
     onLoaded: root.applyEvents(text())
     onLoadFailed: root.applyEvents("")
     onFileChanged: reload()
+  }
+
+  // Copying beats reading a long path back to yourself. Argv array rather than
+  // a shell string, so there is nothing to quote.
+  Process {
+    id: setupCommandCopier
+    command: ["wl-copy", "--", root.setupCommand]
+  }
+
+  property bool setupCommandCopied: false
+
+  function copySetupCommand() {
+    setupCommandCopier.running = true
+    root.setupCommandCopied = true
+    copiedReset.restart()
+  }
+
+  Timer {
+    id: copiedReset
+    interval: 2000
+    onTriggered: root.setupCommandCopied = false
   }
 
   SystemClock {
@@ -1161,14 +1189,30 @@ Panel {
             // An empty day and a sync that never ran look identical unless
             // we say which one it is.
             Text {
+              id: emptyState
               width: parent.width
               visible: root.selectedEvents.length === 0
-              color: Qt.darker(root.contentForeground, 1.9)
+              color: root.syncState === "missing" && emptyHover.hovered
+                ? Style.hoverStateColor(root.contentForeground, Color.accent)
+                : Qt.darker(root.contentForeground, 1.9)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.caption
               wrapMode: Text.WordWrap
+
+              HoverHandler {
+                id: emptyHover
+                enabled: root.syncState === "missing"
+                cursorShape: Qt.PointingHandCursor
+              }
+
+              TapHandler {
+                enabled: root.syncState === "missing"
+                onTapped: root.copySetupCommand()
+              }
               text: root.syncState === "missing"
-                ? qsTr("No calendar synced yet. Run sync/setup.")
+                ? (root.setupCommandCopied
+                  ? qsTr("Copied. Paste it in a terminal:\n%1").arg(root.setupCommand)
+                  : qsTr("No calendar synced yet. Click to copy, then run:\n%1").arg(root.setupCommand))
                 : root.syncState === "version"
                   ? qsTr("Events file was written by a newer version. Update the plugin.")
                   : root.syncState === "stale"
@@ -1198,6 +1242,9 @@ Panel {
             announceLeadMinutes: root.setting("announceLeadMinutes", 15)
 
             syncState: root.syncState
+            setupCommand: root.setupCommand
+            setupCommandCopied: root.setupCommandCopied
+            onSetupCommandCopyRequested: root.copySetupCommand()
             eventCount: root.eventDoc && root.eventDoc.events ? root.eventDoc.events.length : 0
             sourceLabel: root.eventDoc ? String(root.eventDoc.source || "") : ""
             syncedAt: root.eventDoc && root.eventDoc.syncedAt

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ Then:
 omarchy restart shell
 ```
 
-You now have a working calendar with no events in it. Give it a source next.
+**Installing is not the whole job.** At this point you have a working clock and
+an empty calendar, because nothing is feeding it yet. Connect Google Calendar
+below, or point any other source at the file. The widget says as much when you
+open it, with the command to run.
 
 ## Sync your Google Calendar
 

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -26,6 +26,8 @@ Column {
   property string sourceLabel: ""
   property int eventCount: 0
   property string syncState: "missing"
+  property string setupCommand: ""
+  property bool setupCommandCopied: false
 
   signal calendarToggled(string calendarId)
   signal yearProgressToggled()
@@ -33,6 +35,7 @@ Column {
   signal workingLocationToggled()
   signal hideDeclinedToggled()
   signal leadMinutesPicked(int minutes)
+  signal setupCommandCopyRequested()
 
   readonly property color muted: Qt.darker(foreground, 1.5)
   readonly property color faint: Qt.darker(foreground, 1.9)
@@ -241,12 +244,28 @@ Column {
 
   Text {
     width: parent.width
-    color: root.faint
+    color: root.syncState === "missing" && syncHover.hovered ? root.foreground : root.faint
     font.family: root.fontFamily
     font.pixelSize: Style.font.caption
     wrapMode: Text.WordWrap
+
+    HoverHandler {
+      id: syncHover
+      enabled: root.syncState === "missing"
+      cursorShape: Qt.PointingHandCursor
+    }
+
+    TapHandler {
+      enabled: root.syncState === "missing"
+      onTapped: root.setupCommandCopyRequested()
+    }
+
     text: {
-      if (root.syncState === "missing") return qsTr("No events file yet. Run sync/setup to connect a calendar.")
+      if (root.syncState === "missing") {
+        return root.setupCommandCopied
+          ? qsTr("Copied. Paste it in a terminal:\n%1").arg(root.setupCommand)
+          : qsTr("No calendar connected yet. Click to copy, then run:\n%1").arg(root.setupCommand)
+      }
       if (root.syncState === "version") return qsTr("The events file was written by a newer version of this plugin.")
 
       var line = root.eventCount + qsTr(" events from ") + root.sourceLabel

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -397,3 +397,31 @@ test('eventUrlFor mirrors meetingUrlFor and is https only', () => {
   assert.equal(Model.eventUrlFor({}), '')
   assert.equal(Model.eventUrlFor(null), '')
 })
+
+test('commandPathFromUrl strips the file scheme and shortens home', () => {
+  assert.equal(
+    Model.commandPathFromUrl('file:///home/tmn/.config/omarchy/plugins/tmn73.calendar/sync/setup', '/home/tmn'),
+    '~/.config/omarchy/plugins/tmn73.calendar/sync/setup'
+  )
+})
+
+test('commandPathFromUrl leaves a path outside home alone', () => {
+  assert.equal(
+    Model.commandPathFromUrl('file:///opt/omarchy-calendar/sync/setup', '/home/tmn'),
+    '/opt/omarchy-calendar/sync/setup'
+  )
+})
+
+test('commandPathFromUrl tolerates a missing home or url', () => {
+  assert.equal(Model.commandPathFromUrl('file:///srv/x/sync/setup', ''), '/srv/x/sync/setup')
+  assert.equal(Model.commandPathFromUrl('', '/home/tmn'), '')
+  assert.equal(Model.commandPathFromUrl(null, null), '')
+})
+
+test('commandPathFromUrl does not shorten a home-lookalike prefix', () => {
+  // /home/tmn2 must not become ~2
+  assert.equal(
+    Model.commandPathFromUrl('file:///home/tmn2/plugin/sync/setup', '/home/tmn'),
+    '/home/tmn2/plugin/sync/setup'
+  )
+})


### PR DESCRIPTION
## Why

Someone installing from the marketplace listing never opens the README. They end up with a working clock, an empty calendar, and a hint that said `Run sync/setup` without saying where from.

## What's new

- The empty state carries the **whole path** and **copies it on click**, confirming for two seconds.
- The settings page's sync line does the same.
- The README says plainly that installing is not the whole job.

## The path is derived, not hardcoded

`Qt.resolvedUrl("sync/setup")` relative to `Panel.qml`, so it is correct whether the plugin came from `omarchy plugin add` or was cloned somewhere by hand. A wrong path in the one message a new user ever sees would be worse than no message at all.

The URL-to-display-path conversion lives in `Model.js` so it is unit tested, including that a `/home/tmn2` prefix does not get shortened to `~2`.

## Clipboard

`wl-copy` is invoked as a `Process` with an argv array, not through a shell, the same reasoning as the URL opener.

## Tests

104 Python, 65 Node.
