### PR TITLE
Declare MIT in the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,9 @@
   "schemaVersion": 1,
   "id": "tmn73.calendar",
   "name": "Calendar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "tmn73",
+  "license": "MIT",
   "description": "Your Google Calendar in the bar. Your next meeting at a glance, and one click to join it.",
   "kinds": [
     "bar-widget"


### PR DESCRIPTION
The marketplace listing showed `License: See repository` even after GitHub started detecting MIT correctly.

`build-catalog.mjs` reads `manifest.license`, an optional free-text string we never set, so the page had nothing to show. Adding it is the whole fix.

Checked before pushing: Omarchy's own `omarchy plugin validate` tolerates the extra field, and the marketplace validator only requires a non-empty string under 120 characters with no control characters.