### PR TITLE
fix: prefer summaryOverride so renamed subscriptions keep their name

### DIFF
--- a/sync/omarchy_calendar_sync/gws.py
+++ b/sync/omarchy_calendar_sync/gws.py
@@ -79,7 +79,12 @@ class Gws:
         calendars = [
             {
                 "id": item["id"],
-                "name": item.get("summary") or item["id"],
+                # A renamed subscription (ICS feeds especially, whose
+                # summary is whatever the feed called itself) keeps the
+                # user's name in summaryOverride, so prefer that.
+                "name": item.get("summaryOverride")
+                or item.get("summary")
+                or item["id"],
                 "color": item.get("backgroundColor") or FALLBACK_COLOR,
             }
             for item in payload.get("items", [])

--- a/tests/test_gws.py
+++ b/tests/test_gws.py
@@ -83,6 +83,11 @@ class TestCalendars(unittest.TestCase):
         client = gws.Gws("/tmp/profile", runner=FakeRunner({"calendarList": (0, body, "")}))
         self.assertEqual(client.calendars()[0]["color"], gws.FALLBACK_COLOR)
 
+    def test_summary_override_wins_over_summary(self):
+        body = json.dumps({"items": [{"id": "x@import.calendar.google.com", "summary": "Calendar", "summaryOverride": "Fastell Calendar"}]})
+        client = gws.Gws("/tmp/profile", runner=FakeRunner({"calendarList": (0, body, "")}))
+        self.assertEqual(client.calendars()[0]["name"], "Fastell Calendar")
+
     def test_missing_summary_falls_back_to_id(self):
         body = json.dumps({"items": [{"id": "x@example.com", "backgroundColor": "#ffffff"}]})
         client = gws.Gws("/tmp/profile", runner=FakeRunner({"calendarList": (0, body, "")}))


### PR DESCRIPTION
## What

When building the calendar list, use `summaryOverride` before `summary`:

```python
"name": item.get("summaryOverride") or item.get("summary") or item["id"],
```

Adds a unit test for the override case. Existing tests untouched and still green (105 Python, 65 JS).

## Why

Google keeps a user's rename of a subscribed calendar in `summaryOverride` and leaves `summary` as whatever the source called itself. ICS/webcal imports are the common case: an Outlook 365 feed names itself plain "Calendar", so the widget showed "Calendar" even though Google Calendar's sidebar said "Fastell Calendar". The name in the widget's CALENDARS list should match what the user sees in Google.

`calendarList.list` returns `summaryOverride` by default, so no extra API call or params needed.

## Verified

Real account with a renamed webcal subscription: before the patch the sync wrote `calendarName: "Calendar"`, after it writes `"Fastell Calendar"` and the settings panel shows the right name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)