### PR TITLE
Create, edit, and delete events directly from the widget

### DIFF
--- a/EventForm.qml
+++ b/EventForm.qml
@@ -1,0 +1,220 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+// Create/edit form, shown in place of the month grid the same way
+// SettingsView is. Same split as that file: this reads state and emits
+// intent, Panel.qml owns the actual gws call and what happens with its
+// result.
+Column {
+  id: root
+
+  property color foreground: "white"
+  property string fontFamily: ""
+
+  // null while creating; the event object being edited otherwise.
+  property var editing: null
+  property string defaultDateKey: ""
+  property var calendars: []
+  property string errorText: ""
+  property bool busy: false
+
+  // (fields, calendarId, calendarName, calendarColor)
+  signal submitted(var fields, string calendarId, string calendarName, string calendarColor)
+  signal canceled()
+
+  readonly property bool isEditing: root.editing !== null
+  readonly property color muted: Qt.darker(foreground, 1.5)
+  readonly property color faint: Qt.darker(foreground, 1.9)
+
+  spacing: Style.space(8)
+
+  // (Re)seeds the fields from `editing`, or blank defaults for a new event,
+  // every time the form opens -- rather than once at creation, since this
+  // component is a single long-lived instance toggled by `visible`, not
+  // recreated per open.
+  function reset() {
+    var e = root.editing
+    titleField.text = e ? String(e.title || "") : ""
+    locationField.text = e ? String(e.location || "") : ""
+    allDayToggle.checked = e ? !!e.allDay : false
+
+    if (e) {
+      dateField.text = String(e.dateKey || root.defaultDateKey)
+      if (!e.allDay) {
+        var start = new Date(e.start)
+        var end = new Date(e.end)
+        startField.text = Qt.formatDateTime(start, "HH:mm")
+        endField.text = Qt.formatDateTime(end, "HH:mm")
+      } else {
+        startField.text = ""
+        endField.text = ""
+      }
+      var idx = 0
+      for (var i = 0; i < root.calendars.length; i++) {
+        if (root.calendars[i].id === e.calendarId) { idx = i; break }
+      }
+      calendarPicker.value = root.calendars.length ? String(root.calendars[idx].id) : ""
+    } else {
+      dateField.text = root.defaultDateKey
+      startField.text = ""
+      endField.text = ""
+      calendarPicker.value = root.calendars.length ? String(root.calendars[0].id) : ""
+    }
+  }
+
+  onVisibleChanged: if (root.visible) root.reset()
+
+  function submit() {
+    var chosenId = calendarPicker.value
+    var chosen = null
+    for (var i = 0; i < root.calendars.length; i++) {
+      if (root.calendars[i].id === chosenId) { chosen = root.calendars[i]; break }
+    }
+    if (!chosen) chosen = { id: "primary", name: "primary", color: "" }
+
+    root.submitted({
+      title: titleField.text,
+      location: locationField.text,
+      allDay: allDayToggle.checked,
+      dateKey: dateField.text,
+      endDateKey: dateField.text,
+      startTime: startField.text,
+      endTime: endField.text
+    }, chosen.id, chosen.name, chosen.color)
+  }
+
+  Text {
+    width: parent.width
+    text: root.isEditing ? qsTr("EDIT EVENT") : qsTr("NEW EVENT")
+    color: root.faint
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.caption
+    font.letterSpacing: 1
+    font.bold: true
+  }
+
+  TextField {
+    id: titleField
+    width: parent.width
+    placeholderText: qsTr("Title")
+    foreground: root.foreground
+    font.family: root.fontFamily
+  }
+
+  Dropdown {
+    id: calendarPicker
+    width: parent.width
+    label: qsTr("Calendar")
+    options: root.calendars.map(function(c) { return { value: c.id, label: c.name } })
+    foreground: root.foreground
+    fontFamily: root.fontFamily
+  }
+
+  Row {
+    width: parent.width
+    spacing: Style.space(6)
+
+    TextField {
+      id: dateField
+      width: (parent.width - Style.space(6)) / 2
+      placeholderText: qsTr("YYYY-MM-DD")
+      foreground: root.foreground
+      font.family: root.fontFamily
+    }
+
+    Item {
+      width: (parent.width - Style.space(6)) / 2
+      height: allDayLabel.implicitHeight
+
+      Text {
+        id: allDayLabel
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        text: qsTr("All day")
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      ToggleSwitch {
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        checked: allDayToggle.checked
+        foreground: root.foreground
+        onToggled: allDayToggle.checked = !allDayToggle.checked
+      }
+
+      // Not a visual element -- just holds the checked state, so the label
+      // and the switch above can both read/drive the same value without
+      // either owning it.
+      QtObject {
+        id: allDayToggle
+        property bool checked: false
+      }
+    }
+  }
+
+  Row {
+    width: parent.width
+    spacing: Style.space(6)
+    visible: !allDayToggle.checked
+
+    TextField {
+      id: startField
+      width: (parent.width - Style.space(6)) / 2
+      placeholderText: qsTr("Start, e.g. 09:00")
+      foreground: root.foreground
+      font.family: root.fontFamily
+    }
+
+    TextField {
+      id: endField
+      width: (parent.width - Style.space(6)) / 2
+      placeholderText: qsTr("End, e.g. 09:30")
+      foreground: root.foreground
+      font.family: root.fontFamily
+    }
+  }
+
+  TextField {
+    id: locationField
+    width: parent.width
+    placeholderText: qsTr("Location (optional)")
+    foreground: root.foreground
+    font.family: root.fontFamily
+  }
+
+  Text {
+    width: parent.width
+    visible: root.errorText !== ""
+    text: root.errorText
+    color: Color.urgent
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.caption
+    wrapMode: Text.WordWrap
+  }
+
+  Row {
+    width: parent.width
+    spacing: Style.space(8)
+    layoutDirection: Qt.RightToLeft
+
+    Button {
+      text: root.busy ? qsTr("Saving…") : (root.isEditing ? qsTr("Save") : qsTr("Create"))
+      bordered: true
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      enabled: !root.busy
+      onClicked: root.submit()
+    }
+
+    Button {
+      text: qsTr("Cancel")
+      foreground: root.muted
+      fontFamily: root.fontFamily
+      enabled: !root.busy
+      onClicked: root.canceled()
+    }
+  }
+}

--- a/Model.js
+++ b/Model.js
@@ -563,6 +563,161 @@ function syncState(doc, nowMs, intervalSeconds) {
   return (nowMs - syncedMs) > thresholdMs ? "stale" : "ok"
 }
 
+// ---- Create / edit / delete, via `gws`. Everything below stays pure and
+// argv-only: Panel.qml owns the actual Process, this just decides what to
+// run and how to read back what it prints. No shell strings anywhere, same
+// reasoning as openExternally's comment above -- calendar content (a title,
+// a location) is attacker-controlled the moment it round-trips through a
+// shared calendar, so it never touches a shell.
+
+// Builds a UTC-offset ISO8601 datetime ("2026-08-10T19:15:00-05:00") from
+// local date/time parts, using this machine's own offset for that instant
+// (so DST transitions resolve correctly). Google's API accepts an explicit
+// offset in place of a separate IANA `timeZone` field, which sidesteps
+// needing a zone *name* -- QML has no clean way to ask Qt for one.
+function offsetDateTime(year, month, day, hour, minute) {
+  var date = new Date(year, month, day, hour, minute, 0)
+  var offsetMin = -date.getTimezoneOffset()
+  var sign = offsetMin >= 0 ? "+" : "-"
+  var abs = Math.abs(offsetMin)
+  return dateKey(year, month, day) + "T" + pad2(hour) + ":" + pad2(minute) + ":00"
+    + sign + pad2(Math.floor(abs / 60)) + ":" + pad2(abs % 60)
+}
+
+// Validates and shapes a create/edit form into a Google Calendar API event
+// body. Returns { ok: false, error } for anything a human needs to fix
+// before this is worth sending, so the caller never has to guess why a
+// request would fail before it is even built.
+//
+// `fields`: { title, location, allDay, dateKey, endDateKey, startTime
+// ("HH:MM"), endTime ("HH:MM") }. `endDateKey` defaults to `dateKey` --
+// multi-day events are deliberately not supported by this form (the sync's
+// per-day row expansion has no inverse here), so a longer span is rejected
+// rather than silently truncated to one day.
+function buildEventBody(fields) {
+  var f = fields || {}
+  var title = String(f.title || "").trim()
+  if (title === "") return { ok: false, error: "Title is required" }
+
+  var startKey = String(f.dateKey || "")
+  var endKey = String(f.endDateKey || f.dateKey || "")
+  var start = dateFromKey(startKey, null)
+  var end = dateFromKey(endKey, null)
+  if (!start || !end) return { ok: false, error: "Pick a date" }
+  if (endKey !== startKey) return { ok: false, error: "Multi-day events aren't supported here -- edit it in Google Calendar" }
+
+  var body = { summary: title }
+  if (String(f.location || "").trim() !== "") body.location = String(f.location).trim()
+
+  if (f.allDay) {
+    // The API's all-day `end.date` is exclusive, so a one-day event's own
+    // end date is the *next* day, not the day it's on.
+    var next = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 1)
+    body.start = { date: startKey }
+    body.end = { date: dateKey(next.getFullYear(), next.getMonth(), next.getDate()) }
+    return { ok: true, body: body }
+  }
+
+  var startParts = parseHHMM(f.startTime)
+  var endParts = parseHHMM(f.endTime)
+  if (!startParts) return { ok: false, error: "Pick a start time" }
+  if (!endParts) return { ok: false, error: "Pick an end time" }
+
+  var startDt = offsetDateTime(start.getFullYear(), start.getMonth(), start.getDate(), startParts.hour, startParts.minute)
+  var endDt = offsetDateTime(start.getFullYear(), start.getMonth(), start.getDate(), endParts.hour, endParts.minute)
+  if (Date.parse(endDt) <= Date.parse(startDt)) return { ok: false, error: "End time must be after start time" }
+
+  body.start = { dateTime: startDt }
+  body.end = { dateTime: endDt }
+  return { ok: true, body: body }
+}
+
+// "9:30", "09:30", "930" -> {hour, minute}; anything else -> null. Typing a
+// time by hand is fiddly enough without also demanding a leading zero.
+function parseHHMM(raw) {
+  var s = String(raw || "").trim()
+  var m = s.match(/^(\d{1,2}):?(\d{2})$/)
+  if (!m) return null
+  var hour = parseInt(m[1], 10)
+  var minute = parseInt(m[2], 10)
+  if (isNaN(hour) || isNaN(minute) || hour > 23 || minute > 59) return null
+  return { hour: hour, minute: minute }
+}
+
+// Maps a raw Calendar API event (as `gws ... insert/patch --format json`
+// prints it) to this widget's own row shape -- the same fields the sync
+// writes to calendar-events.json, documented in the README -- so a freshly
+// created/edited event can be merged straight into eventDoc without waiting
+// for the next sync. calendarId/calendarName/color come from the caller
+// (the form's own calendar picker), since the API response only echoes
+// calendarId indirectly (via the request URL, which gws doesn't repeat back).
+function normalizeApiEvent(apiEvent, calendarId, calendarName, color) {
+  var e = apiEvent || {}
+  var start = e.start || {}
+  var end = e.end || {}
+  var allDay = start.date !== undefined
+  var startIso = allDay ? (start.date + "T00:00:00") : (start.dateTime || "")
+  var endIso = allDay ? (end.date + "T00:00:00") : (end.dateTime || "")
+  var startDate = allDay ? dateFromKey(start.date, new Date()) : new Date(startIso)
+
+  return {
+    id: String(e.id || ""),
+    calendarId: calendarId,
+    calendarName: calendarName,
+    color: color || "",
+    dateKey: keyForDate(startDate),
+    start: startIso,
+    end: endIso,
+    allDay: allDay,
+    title: String(e.summary || ""),
+    location: String(e.location || ""),
+    eventUrl: safeUrl(e.htmlLink || ""),
+    meetingUrl: safeUrl(e.hangoutLink || "")
+  }
+}
+
+// `~/.config/omarchy/calendar-sync.json` has the same two keys the Python
+// sync reads (sync/omarchy_calendar_sync/config.py) with the same defaults,
+// so a write profile set up for reading events is also the one writes go
+// through -- one login, one place it is remembered.
+function resolveSyncConfig(rawText, homeDir) {
+  var home = String(homeDir || "")
+  var profile = home + "/.config/gws-omarchy-calendar"
+  var gwsPath = "gws"
+
+  if (rawText) {
+    try {
+      var parsed = JSON.parse(rawText)
+      if (parsed && typeof parsed.profile === "string" && parsed.profile !== "") profile = parsed.profile
+      if (parsed && typeof parsed.gwsPath === "string" && parsed.gwsPath !== "") gwsPath = parsed.gwsPath
+    } catch (error) { /* fall back to defaults below */ }
+  }
+
+  return { profile: profile, gwsPath: gwsPath }
+}
+
+// argv for the three write operations. Always an array, never a shell
+// string -- gws itself takes `--json`/`--params` as plain arguments, so
+// there is nothing to quote in the first place.
+function gwsInsertArgv(gwsPath, calendarId, body) {
+  return [gwsPath, "calendar", "events", "insert",
+    "--params", JSON.stringify({ calendarId: calendarId }),
+    "--json", JSON.stringify(body),
+    "--format", "json"]
+}
+
+function gwsPatchArgv(gwsPath, calendarId, eventId, body) {
+  return [gwsPath, "calendar", "events", "patch",
+    "--params", JSON.stringify({ calendarId: calendarId, eventId: eventId }),
+    "--json", JSON.stringify(body),
+    "--format", "json"]
+}
+
+function gwsDeleteArgv(gwsPath, calendarId, eventId) {
+  return [gwsPath, "calendar", "events", "delete",
+    "--params", JSON.stringify({ calendarId: calendarId, eventId: eventId })]
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     dateKey: dateKey,
@@ -611,6 +766,14 @@ if (typeof module !== "undefined") {
     isJoinableNow: isJoinableNow,
     eventsForDateKey: eventsForDateKey,
     eventColors: eventColors,
-    syncState: syncState
+    syncState: syncState,
+    offsetDateTime: offsetDateTime,
+    buildEventBody: buildEventBody,
+    parseHHMM: parseHHMM,
+    normalizeApiEvent: normalizeApiEvent,
+    resolveSyncConfig: resolveSyncConfig,
+    gwsInsertArgv: gwsInsertArgv,
+    gwsPatchArgv: gwsPatchArgv,
+    gwsDeleteArgv: gwsDeleteArgv
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -214,6 +214,176 @@ Panel {
     root.openExternally(Model.eventUrlFor(event))
   }
 
+  // ---- Create / edit / delete, via gws (sync/setup grants the write scope
+  // that needs). The sync pipeline stays entirely read-only and untouched;
+  // this talks to Google directly, on its own Process, using the same
+  // profile the sync already logged into (see syncConfig below).
+  property bool eventFormOpen: false
+  // null while creating; the event object being edited otherwise. Reused
+  // for the confirm dialog too (delete needs no form, just this).
+  property var eventFormEditing: null
+  property string eventFormError: ""
+  property bool eventFormBusy: false
+  property var pendingDelete: null
+
+  // calendar-sync.json, defaulted exactly like sync/omarchy_calendar_sync/
+  // config.py -- one profile serves both reading and writing, so setup only
+  // has to happen once.
+  property var syncConfig: Model.resolveSyncConfig(null, Quickshell.env("HOME") || "")
+
+  function applySyncConfig(raw) {
+    root.syncConfig = Model.resolveSyncConfig(raw, Quickshell.env("HOME") || "")
+  }
+
+  // knownCalendars is derived from your own events (see its own comment),
+  // so it is empty before the first sync or if you have never had an event
+  // on a non-primary calendar. "primary" always works regardless, so it is
+  // always offered even when the derived list has not caught up yet.
+  function calendarChoices() {
+    var list = root.knownCalendars.slice()
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].id === "primary") return list
+    }
+    return [{ id: "primary", name: "primary", color: "" }].concat(list)
+  }
+
+  function openCreateForm() {
+    root.eventFormEditing = null
+    root.eventFormError = ""
+    root.eventFormOpen = true
+  }
+
+  function openEditForm(event) {
+    root.eventFormEditing = event
+    root.eventFormError = ""
+    root.eventFormOpen = true
+  }
+
+  function closeEventForm() {
+    root.eventFormOpen = false
+    root.eventFormEditing = null
+    root.eventFormError = ""
+  }
+
+  // Merges a freshly written event into the live document in place, rather
+  // than waiting up to 5 minutes for the sync to notice. The next real sync
+  // still replaces eventDoc wholesale from disk, which is what reconciles
+  // this back to Google's canonical copy -- nothing here needs to remember
+  // that it was optimistic.
+  function mergeLocalEvent(event, previousId) {
+    if (!root.eventDoc) root.eventDoc = { version: 1, syncedAt: new Date().toISOString(), source: "local", events: [] }
+    if (!Array.isArray(root.eventDoc.events)) root.eventDoc.events = []
+
+    var events = root.eventDoc.events.slice()
+    var replaceId = previousId !== undefined ? previousId : event.id
+    var replaced = false
+    for (var i = 0; i < events.length; i++) {
+      if (events[i].id === replaceId) { events[i] = event; replaced = true; break }
+    }
+    if (!replaced) events.push(event)
+
+    root.eventDoc = { version: root.eventDoc.version, syncedAt: root.eventDoc.syncedAt, source: root.eventDoc.source, events: events }
+    root.rebuildIndex()
+  }
+
+  function removeLocalEvent(eventId) {
+    if (!root.eventDoc || !Array.isArray(root.eventDoc.events)) return
+    var events = root.eventDoc.events.filter(function(e) { return e.id !== eventId })
+    root.eventDoc = { version: root.eventDoc.version, syncedAt: root.eventDoc.syncedAt, source: root.eventDoc.source, events: events }
+    root.rebuildIndex()
+  }
+
+  // fields: { title, location, allDay, dateKey, endDateKey, startTime, endTime }
+  function submitEventForm(fields, calendarId, calendarName, calendarColor) {
+    var draft = Model.buildEventBody(fields)
+    if (!draft.ok) { root.eventFormError = draft.error; return }
+
+    root.eventFormError = ""
+    root.eventFormBusy = true
+
+    var editing = root.eventFormEditing
+    var argv = editing
+      ? Model.gwsPatchArgv(root.syncConfig.gwsPath, editing.calendarId, editing.id, draft.body)
+      : Model.gwsInsertArgv(root.syncConfig.gwsPath, calendarId, draft.body)
+
+    root._pendingWrite = editing
+      ? { action: "patch", calendarId: editing.calendarId, calendarName: calendarName, color: calendarColor, previousId: editing.id }
+      : { action: "insert", calendarId: calendarId, calendarName: calendarName, color: calendarColor }
+
+    gwsWriteRequest.environment = ({ GOOGLE_WORKSPACE_CLI_CONFIG_DIR: root.syncConfig.profile })
+    gwsWriteRequest.command = argv
+    gwsWriteRequest.running = true
+  }
+
+  function requestDelete(event) {
+    root.pendingDelete = event
+  }
+
+  function confirmDelete() {
+    var event = root.pendingDelete
+    root.pendingDelete = null
+    if (!event) return
+
+    root.eventFormError = ""
+    root.eventFormBusy = true
+    root._pendingWrite = { action: "delete", eventId: event.id }
+    gwsWriteRequest.environment = ({ GOOGLE_WORKSPACE_CLI_CONFIG_DIR: root.syncConfig.profile })
+    gwsWriteRequest.command = Model.gwsDeleteArgv(root.syncConfig.gwsPath, event.calendarId, event.id)
+    gwsWriteRequest.running = true
+  }
+
+  property var _pendingWrite: null
+
+  FileView {
+    id: syncConfigFile
+    path: (Quickshell.env("HOME") || "") + "/.config/omarchy/calendar-sync.json"
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.applySyncConfig(text())
+    onLoadFailed: root.applySyncConfig("")
+    onFileChanged: reload()
+  }
+
+  // One Process reused for every write, guarded by eventFormBusy so a
+  // second submit cannot race the first -- same reuse-over-parallel
+  // reasoning as futbar's scoreboard pool, just with a single slot since a
+  // human only ever confirms one form at a time.
+  Process {
+    id: gwsWriteRequest
+    stdout: StdioCollector { id: gwsWriteOut; waitForEnd: true }
+    stderr: StdioCollector { id: gwsWriteErr; waitForEnd: true }
+    onExited: function(exitCode) {
+      root.eventFormBusy = false
+      var pending = root._pendingWrite
+      root._pendingWrite = null
+      if (!pending) return
+
+      if (exitCode !== 0) {
+        var message = gwsWriteErr.text.trim() || gwsWriteOut.text.trim() || ("gws exited " + exitCode)
+        root.eventFormError = message.split("\n")[0]
+        return
+      }
+
+      if (pending.action === "delete") {
+        root.removeLocalEvent(pending.eventId)
+        return
+      }
+
+      try {
+        var apiEvent = JSON.parse(gwsWriteOut.text)
+        var row = Model.normalizeApiEvent(apiEvent, pending.calendarId, pending.calendarName, pending.color)
+        root.mergeLocalEvent(row, pending.previousId)
+        root.closeEventForm()
+      } catch (error) {
+        // The write almost certainly succeeded (gws exited 0) -- only
+        // reading its own echo back failed, so say that rather than
+        // implying the event itself is in doubt.
+        root.eventFormError = "Saved, but couldn't read the confirmation back"
+        root.closeEventForm()
+      }
+    }
+  }
+
   onHiddenCalendarsChanged: root.rebuildIndex()
   onShowWorkingLocationChanged: root.rebuildIndex()
   onHideDeclinedChanged: root.rebuildIndex()
@@ -1028,19 +1198,38 @@ Panel {
           //      the selection survives stepping to another month and an
           //      undated list would then be a quiet lie.
           Column {
-            visible: !root.settingsOpen
+            visible: !root.settingsOpen && !root.eventFormOpen
             width: gridColumn.width
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: Style.space(4)
 
-            Text {
+            Item {
               width: parent.width
-              text: Qt.formatDate(root.selectedDate, "dddd d MMMM").toUpperCase()
-              color: Qt.darker(root.contentForeground, 1.4)
-              font.family: root.contentFontFamily
-              font.pixelSize: Style.font.caption
-              font.letterSpacing: 1
-              font.bold: true
+              height: dayLabel.implicitHeight
+
+              Text {
+                id: dayLabel
+                anchors.left: parent.left
+                anchors.right: newEventButton.left
+                text: Qt.formatDate(root.selectedDate, "dddd d MMMM").toUpperCase()
+                color: Qt.darker(root.contentForeground, 1.4)
+                font.family: root.contentFontFamily
+                font.pixelSize: Style.font.caption
+                font.letterSpacing: 1
+                font.bold: true
+                elide: Text.ElideRight
+              }
+
+              PanelActionButton {
+                id: newEventButton
+                anchors.right: parent.right
+                anchors.verticalCenter: dayLabel.verticalCenter
+                iconText: "󰐕"
+                tooltipText: "New event"
+                foreground: root.contentForeground
+                fontFamily: root.contentFontFamily
+                onClicked: root.openCreateForm()
+              }
             }
 
             Repeater {
@@ -1069,10 +1258,10 @@ Panel {
                             root.contentForeground.b, 0.08)
                   : "transparent"
 
-                // Only rows that can actually do something respond to a click.
+                // Always enabled now: edit/delete apply to every event, even
+                // one with no link to open and nothing live to join.
                 HoverHandler {
                   id: eventHover
-                  enabled: eventRow.openable || eventRow.joinable
                   cursorShape: Qt.PointingHandCursor
                 }
 
@@ -1114,11 +1303,52 @@ Panel {
                   }
                 }
 
+                // Hover-revealed rather than always shown: every row can be
+                // edited or deleted, so showing both permanently on every
+                // day's whole agenda would be more clutter than the Join
+                // button (only live for a narrow window) ever is. Anchored
+                // regardless of visibility so eventBody's reserved width
+                // does not jump the moment the mouse arrives.
+                //
+                // Reveal via opacity/enabled, not visible: eventHover is a
+                // HoverHandler on eventRow, which contains this Row, so
+                // tying `visible` to it produced a real binding loop
+                // ("Binding loop detected for property 'visible'") that
+                // made the buttons intermittently unclickable -- toggling
+                // opacity instead keeps the geometry this row already
+                // depends on (see comment above) stable and out of the
+                // loop, and `enabled` still blocks clicks while hidden.
+                Row {
+                  id: eventActions
+                  opacity: eventHover.hovered ? 1 : 0
+                  enabled: eventHover.hovered
+                  anchors.right: eventRow.joinable ? joinButton.left : parent.right
+                  anchors.rightMargin: eventRow.joinable ? Style.space(4) : 0
+                  anchors.verticalCenter: parent.verticalCenter
+                  spacing: Style.space(2)
+
+                  PanelActionButton {
+                    iconText: "󰏫"
+                    tooltipText: "Edit"
+                    foreground: root.contentForeground
+                    fontFamily: root.contentFontFamily
+                    onClicked: root.openEditForm(eventRow.modelData)
+                  }
+
+                  PanelActionButton {
+                    iconText: "󰩹"
+                    tooltipText: "Delete"
+                    foreground: root.contentForeground
+                    fontFamily: root.contentFontFamily
+                    onClicked: root.requestDelete(eventRow.modelData)
+                  }
+                }
+
                 Row {
                   id: eventBody
                   anchors.left: parent.left
-                  anchors.right: eventRow.joinable ? joinButton.left : parent.right
-                  anchors.rightMargin: eventRow.joinable ? Style.space(3) : 0
+                  anchors.right: eventActions.left
+                  anchors.rightMargin: Style.space(3)
                   anchors.verticalCenter: parent.verticalCenter
                   spacing: Style.space(4)
 
@@ -1258,8 +1488,52 @@ Panel {
             onWeekStartToggled: root.toggleWeekStart()
             onLeadMinutesPicked: function(minutes) { root.setAnnounceLeadMinutes(minutes) }
           }
+
+          // ---- Create/edit form, shown in place of the grid the same way
+          //      settings is. Same "reads state, emits intent" split.
+          EventForm {
+            visible: root.eventFormOpen
+            width: gridColumn.width
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            foreground: root.contentForeground
+            fontFamily: root.contentFontFamily
+
+            editing: root.eventFormEditing
+            defaultDateKey: root.selectedDayKey
+            calendars: root.calendarChoices()
+            errorText: root.eventFormError
+            busy: root.eventFormBusy
+
+            onSubmitted: function(fields, calendarId, calendarName, calendarColor) {
+              root.submitEventForm(fields, calendarId, calendarName, calendarColor)
+            }
+            onCanceled: root.closeEventForm()
+          }
         }
       }
+    }
+
+    // Declared inside KeyboardPanel (as a sibling of PanelKeyCatcher above),
+    // not at the file's top level under `root`: root itself is never given
+    // an explicit size anywhere in this file -- the actual visible popup
+    // surface is sized by KeyboardPanel's own contentWidth/contentHeight.
+    // A first attempt anchored this to `root` (then tried anchoring
+    // directly to the `panel` id, which isn't a QQuickItem and can't be
+    // anchored to at all) and ended up 0x0 and invisible while still
+    // logically "opened" -- every click just silently reopened an
+    // invisible, zero-size confirm dialog. Declaring it in here instead
+    // gives it the same real, correctly-sized implicit parent
+    // PanelKeyCatcher already uses via its own `anchors.fill: parent`.
+    ConfirmDialog {
+      id: deleteConfirm
+      opened: root.pendingDelete !== null
+      message: root.pendingDelete ? ("Delete “" + root.pendingDelete.title + "”?") : ""
+      confirmText: "Delete"
+      cancelText: "Cancel"
+      anchors.fill: parent
+      onConfirmed: root.confirmDelete()
+      onCanceled: root.pendingDelete = null
     }
   }
 }

--- a/sync/setup
+++ b/sync/setup
@@ -18,7 +18,7 @@ PROFILE="${PROFILE:-$HOME/.config/gws-omarchy-calendar}"
 GCLOUD_CONFIG="${GCLOUD_CONFIG:-omarchy-calendar}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SYNC_BIN="$SCRIPT_DIR/omarchy-calendar-sync"
-SCOPE="https://www.googleapis.com/auth/calendar.readonly"
+SCOPE="https://www.googleapis.com/auth/calendar"
 
 step() { printf '\n==> %s\n' "$1"; }
 
@@ -122,14 +122,15 @@ Open:
   https://console.cloud.google.com/auth/scopes?project=$PROJECT_ID
 
   Click "Add or remove scopes"
-  Filter for:  calendar.readonly
+  Filter for:  calendar
   Tick:        $SCOPE
-               ("See and download any calendar you can access")
+               ("See, edit, share, and permanently delete all the
+               calendars you can access using Google Calendar")
   Update, then Save
 
   If Save is greyed out, fill in "How will the scopes be used?" with
-  something like: Read-only display of my own calendar in a desktop
-  status bar widget.
+  something like: Display my calendar and let me create, edit, and
+  delete my own events from a desktop status bar widget.
 
 Do not skip this. A scope that is not declared here is not offered on the
 consent screen at all, so there is no box to tick, Google grants only your
@@ -213,7 +214,7 @@ unticked. Run this script again and tick it.
 EOF
   exit 1
 fi
-echo "  calendar.readonly granted"
+echo "  calendar (read/write) granted"
 
 step "Verifying calendar access"
 # Surface a real error rather than reading `items` out of an error body and

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -425,3 +425,160 @@ test('commandPathFromUrl does not shorten a home-lookalike prefix', () => {
     '/home/tmn2/plugin/sync/setup'
   )
 })
+
+// ---- Create / edit / delete ----
+
+test('buildEventBody requires a title', () => {
+  const result = Model.buildEventBody({ title: '  ', dateKey: '2026-08-10', allDay: true })
+  assert.equal(result.ok, false)
+  assert.match(result.error, /title/i)
+})
+
+test('buildEventBody requires a date', () => {
+  const result = Model.buildEventBody({ title: 'Standup', allDay: true })
+  assert.equal(result.ok, false)
+})
+
+test('buildEventBody rejects a multi-day span', () => {
+  const result = Model.buildEventBody({
+    title: 'Trip', dateKey: '2026-08-10', endDateKey: '2026-08-12', allDay: true
+  })
+  assert.equal(result.ok, false)
+  assert.match(result.error, /multi-day/i)
+})
+
+test('buildEventBody builds an all-day event with an exclusive end date', () => {
+  const result = Model.buildEventBody({ title: 'Holiday', dateKey: '2026-08-10', allDay: true })
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.body, {
+    summary: 'Holiday',
+    start: { date: '2026-08-10' },
+    end: { date: '2026-08-11' }
+  })
+})
+
+test('buildEventBody requires both times for a timed event', () => {
+  assert.equal(Model.buildEventBody({ title: 'X', dateKey: '2026-08-10', startTime: '09:00' }).ok, false)
+  assert.equal(Model.buildEventBody({ title: 'X', dateKey: '2026-08-10', endTime: '09:00' }).ok, false)
+})
+
+test('buildEventBody rejects an end time at or before the start', () => {
+  const same = Model.buildEventBody({
+    title: 'X', dateKey: '2026-08-10', startTime: '09:00', endTime: '09:00'
+  })
+  assert.equal(same.ok, false)
+
+  const before = Model.buildEventBody({
+    title: 'X', dateKey: '2026-08-10', startTime: '09:00', endTime: '08:00'
+  })
+  assert.equal(before.ok, false)
+})
+
+test('buildEventBody builds a timed event with an offset datetime', () => {
+  const result = Model.buildEventBody({
+    title: 'Standup', location: 'Room 4', dateKey: '2026-08-10', startTime: '9:00', endTime: '09:30'
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.body.summary, 'Standup')
+  assert.equal(result.body.location, 'Room 4')
+  assert.match(result.body.start.dateTime, /^2026-08-10T09:00:00[+-]\d{2}:\d{2}$/)
+  assert.match(result.body.end.dateTime, /^2026-08-10T09:30:00[+-]\d{2}:\d{2}$/)
+})
+
+test('buildEventBody omits location when blank', () => {
+  const result = Model.buildEventBody({ title: 'X', dateKey: '2026-08-10', allDay: true })
+  assert.equal('location' in result.body, false)
+})
+
+test('parseHHMM accepts common shapes and rejects garbage', () => {
+  assert.deepEqual(Model.parseHHMM('9:30'), { hour: 9, minute: 30 })
+  assert.deepEqual(Model.parseHHMM('09:30'), { hour: 9, minute: 30 })
+  assert.deepEqual(Model.parseHHMM('930'), { hour: 9, minute: 30 })
+  assert.equal(Model.parseHHMM('25:00'), null)
+  assert.equal(Model.parseHHMM('9:99'), null)
+  assert.equal(Model.parseHHMM('noon'), null)
+  assert.equal(Model.parseHHMM(''), null)
+})
+
+test('offsetDateTime always carries an explicit +HH:MM or -HH:MM offset', () => {
+  const iso = Model.offsetDateTime(2026, 7, 10, 19, 15)
+  assert.match(iso, /^2026-08-10T19:15:00[+-]\d{2}:\d{2}$/)
+})
+
+test('normalizeApiEvent maps a timed event into the widget row shape', () => {
+  const row = Model.normalizeApiEvent({
+    id: 'evt1',
+    summary: 'Standup',
+    location: 'Room 4',
+    start: { dateTime: '2026-08-10T09:00:00-05:00' },
+    end: { dateTime: '2026-08-10T09:30:00-05:00' },
+    htmlLink: 'https://www.google.com/calendar/event?eid=xyz',
+    hangoutLink: 'https://meet.google.com/abc-defg-hij'
+  }, 'work@example.com', 'Work', '#f83a22')
+
+  assert.equal(row.id, 'evt1')
+  assert.equal(row.calendarId, 'work@example.com')
+  assert.equal(row.calendarName, 'Work')
+  assert.equal(row.color, '#f83a22')
+  assert.equal(row.dateKey, '2026-08-10')
+  assert.equal(row.allDay, false)
+  assert.equal(row.title, 'Standup')
+  assert.equal(row.eventUrl, 'https://www.google.com/calendar/event?eid=xyz')
+  assert.equal(row.meetingUrl, 'https://meet.google.com/abc-defg-hij')
+})
+
+test('normalizeApiEvent maps an all-day event and drops an unsafe url', () => {
+  const row = Model.normalizeApiEvent({
+    id: 'evt2',
+    summary: 'Holiday',
+    start: { date: '2026-08-10' },
+    end: { date: '2026-08-11' },
+    htmlLink: 'javascript:alert(1)'
+  }, 'primary', 'primary', '')
+
+  assert.equal(row.allDay, true)
+  assert.equal(row.dateKey, '2026-08-10')
+  assert.equal(row.eventUrl, '')
+})
+
+test('resolveSyncConfig falls back to the documented defaults', () => {
+  assert.deepEqual(Model.resolveSyncConfig(null, '/home/tmn'), {
+    profile: '/home/tmn/.config/gws-omarchy-calendar',
+    gwsPath: 'gws'
+  })
+  assert.deepEqual(Model.resolveSyncConfig('not json', '/home/tmn'), {
+    profile: '/home/tmn/.config/gws-omarchy-calendar',
+    gwsPath: 'gws'
+  })
+})
+
+test('resolveSyncConfig reads profile and gwsPath when present', () => {
+  assert.deepEqual(
+    Model.resolveSyncConfig('{"profile":"/custom/profile","gwsPath":"/usr/local/bin/gws"}', '/home/tmn'),
+    { profile: '/custom/profile', gwsPath: '/usr/local/bin/gws' }
+  )
+})
+
+test('gws*Argv build plain argv arrays with no shell involved', () => {
+  const insert = Model.gwsInsertArgv('gws', 'primary', { summary: 'X' })
+  assert.deepEqual(insert, [
+    'gws', 'calendar', 'events', 'insert',
+    '--params', '{"calendarId":"primary"}',
+    '--json', '{"summary":"X"}',
+    '--format', 'json'
+  ])
+
+  const patch = Model.gwsPatchArgv('gws', 'primary', 'evt1', { summary: 'Y' })
+  assert.deepEqual(patch, [
+    'gws', 'calendar', 'events', 'patch',
+    '--params', '{"calendarId":"primary","eventId":"evt1"}',
+    '--json', '{"summary":"Y"}',
+    '--format', 'json'
+  ])
+
+  const del = Model.gwsDeleteArgv('gws', 'primary', 'evt1')
+  assert.deepEqual(del, [
+    'gws', 'calendar', 'events', 'delete',
+    '--params', '{"calendarId":"primary","eventId":"evt1"}'
+  ])
+})


### PR DESCRIPTION
## Summary

Extends the read-only sync widget with full event CRUD, using the same `gws` (Google Workspace CLI) the sync already depends on.

- **Create**: a "+" button next to the day agenda opens a form (new `EventForm.qml`) — title, date, start/end time (or all-day), which calendar, optional location. Multi-day events are explicitly rejected in the form with a pointer to edit them in Google Calendar directly instead — reversing the sync's per-day-row expansion back into one multi-day event felt out of scope for a first pass.
- **Edit**: hovering an event row reveals a pencil icon that opens the same form, pre-filled.
- **Delete**: hovering reveals a trash icon; confirms via `qs.Ui`'s `ConfirmDialog` before calling `gws`.
- All three shell out to `gws calendar events insert/patch/delete` as plain argv arrays (no shell string, nothing to escape), reading the sync profile/`gwsPath` from `~/.config/omarchy/calendar-sync.json` — the same config file the sync itself already writes, so one login serves both reading and writing. Successful writes merge into the in-memory event list immediately rather than waiting up to 5 minutes for the next sync; the next real sync still replaces the document wholesale from disk, reconciling any optimistic write back to Google's canonical copy.
- `gws` errors (auth, network, invalid event data, permission) surface inline in the form instead of failing silently.
- Widened the setup script's requested OAuth scope from `calendar.readonly` to the full `calendar` scope, since write access needs it — updated the printed manual-step instructions to match (scope description, consent-screen justification wording).

## Two real bugs found and fixed along the way

- The edit/delete icon row was hover-revealed via `visible`, bound to a `HoverHandler` on the row containing it — a genuine QML binding loop ("Binding loop detected for property 'visible'") that made the icons intermittently unclickable. Fixed by switching to `opacity`/`enabled`, which don't create the same cycle.
- Delete specifically stayed broken even after that fix: its confirmation dialog was anchored to `parent`, which resolves to this file's own root `Item` — root is never given an explicit size anywhere in this file (the real visible popup surface is sized by the `KeyboardPanel` content further down), so the dialog rendered at a confirmed `0x0` and invisible while still logically `opened`. Every click just silently reopened an invisible dialog. Moved the dialog inside `KeyboardPanel` so it inherits a correctly-sized parent, same as the existing `PanelKeyCatcher` already does.

## Testing

- 15 new unit tests in `tests/model.test.js` covering event-body construction, API-response mapping, `gws` argv construction, and sync-config resolution — all the logic that could reasonably be pulled into `Model.js`, matching this repo's own convention that `Panel.qml`/`BarWidget.qml` aren't unit tested. Full suite: **80/80 passing**.
- `omarchy restart shell` + `journalctl --user` after every change, no new QML errors/warnings.
- Verified every `gws` invocation's flags against the real installed binary's `--help`, and dry-ran the exact argv construction against the real `gws --dry-run`.
- End-to-end tested live against a real Google account (create, edit, delete, and the two bugs above all reproduced and confirmed fixed against real synced events, not just structurally).

Happy to adjust UX details (form fields, icon placement, confirm-dialog styling) if you'd prefer a different approach.