### PR TITLE
feat: make agenda time format configurable

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -95,6 +95,7 @@ Panel {
   property string selectedDayKey: todayKey
   readonly property var selectedEvents: Model.eventsForDateKey(eventIndex, selectedDayKey)
   readonly property date selectedDate: Model.dateFromKey(selectedDayKey, today)
+  readonly property string eventTimeFormat: String(setting("eventTimeFormat", "HH:mm") || "HH:mm")
 
   function selectDay(key) {
     root.selectedDayKey = String(key)
@@ -231,6 +232,32 @@ Panel {
   readonly property int cellSpacing: Style.space(2)
   readonly property int weekColumnWidth: Style.space(32)
   readonly property int gutterWidth: Style.space(14)
+  readonly property int eventTimeColumnWidth: Math.ceil(Math.max(
+    allDayTimeMetrics.tightBoundingRect.width,
+    morningTimeMetrics.tightBoundingRect.width,
+    eveningTimeMetrics.tightBoundingRect.width
+  )) + Style.space(2)
+
+  TextMetrics {
+    id: allDayTimeMetrics
+    font.family: root.contentFontFamily
+    font.pixelSize: Style.font.bodySmall
+    text: qsTr("All day")
+  }
+
+  TextMetrics {
+    id: morningTimeMetrics
+    font.family: root.contentFontFamily
+    font.pixelSize: Style.font.bodySmall
+    text: Qt.formatDateTime(new Date(2000, 0, 1, 0, 59), root.eventTimeFormat)
+  }
+
+  TextMetrics {
+    id: eveningTimeMetrics
+    font.family: root.contentFontFamily
+    font.pixelSize: Style.font.bodySmall
+    text: Qt.formatDateTime(new Date(2000, 0, 1, 23, 59), root.eventTimeFormat)
+  }
 
   function open() {
     refresh()
@@ -1141,10 +1168,11 @@ Panel {
                 }
 
                 Text {
-                  width: Style.space(44)
+                  id: eventTime
+                  width: root.eventTimeColumnWidth
                   text: eventRow.modelData.allDay
                     ? qsTr("All day")
-                    : Qt.formatDateTime(new Date(eventRow.modelData.start), "HH:mm")
+                    : Qt.formatDateTime(new Date(eventRow.modelData.start), root.eventTimeFormat)
                   color: Qt.darker(root.contentForeground, eventRow.declined ? 2.2 : 1.5)
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
@@ -1153,7 +1181,7 @@ Panel {
 
                 Column {
                   id: eventLines
-                  width: eventBody.width - Style.space(54)
+                  width: Math.max(0, eventBody.width - eventTime.width - Style.space(10))
                   spacing: Style.space(1)
 
                   Text {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ remove the `omarchy.clock` entry from `bar.layout.center` and point
     "centerAnchor": "tmn73.calendar",
     "layout": {
       "center": [
-        { "id": "tmn73.calendar", "format": "dddd HH:mm" }
+        {
+          "id": "tmn73.calendar",
+          "format": "dddd HH:mm",
+          "eventTimeFormat": "HH:mm"
+        }
       ]
     }
   }
@@ -182,6 +186,7 @@ Click the clock, then the gear icon in the panel header.
 | Declined invitations | On lists them struck through, off hides them entirely |
 | Year and life progress | Brings back the built-in clock's bars, off by default |
 | Bar label | How early the bar announces what is next: never, 5, 15, 30 or 60 minutes |
+| Event times | Set `eventTimeFormat` in `shell.json` to a Qt date-time format such as `HH:mm` or `h:mm AP` |
 | Sync | Event count, source and last sync time, for diagnosing a quiet calendar |
 
 Hiding a calendar is instant and does not change what the sync fetches, so

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "tmn73.calendar",
   "name": "Calendar",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "tmn73",
   "license": "MIT",
   "description": "Your Google Calendar in the bar. Your next meeting at a glance, and one click to join it.",
@@ -20,7 +20,8 @@
     "defaults": {
       "format": "dddd HH:mm",
       "formatAlt": "d MMMM 'W'ww yyyy",
-      "verticalFormat": "HH\n-\nmm"
+      "verticalFormat": "HH\n-\nmm",
+      "eventTimeFormat": "HH:mm"
     },
     "schema": [
       {
@@ -40,6 +41,12 @@
         "type": "string",
         "label": "Vertical bar format",
         "defaultValue": "HH\n-\nmm"
+      },
+      {
+        "key": "eventTimeFormat",
+        "type": "string",
+        "label": "Event time format",
+        "defaultValue": "HH:mm"
       },
       {
         "key": "birthYear",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,26 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestManifest(unittest.TestCase):
+    def setUp(self):
+        self.manifest = json.loads((ROOT / "manifest.json").read_text())
+
+    def test_event_time_format_has_a_24_hour_default(self):
+        defaults = self.manifest["barWidget"]["defaults"]
+        self.assertEqual(defaults["eventTimeFormat"], "HH:mm")
+
+    def test_event_time_format_is_exposed_in_the_schema(self):
+        schema = {
+            item["key"]: item for item in self.manifest["barWidget"]["schema"]
+        }
+        self.assertEqual(schema["eventTimeFormat"]["type"], "string")
+        self.assertEqual(schema["eventTimeFormat"]["defaultValue"], "HH:mm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an eventTimeFormat bar-widget setting while preserving the existing HH:mm default. The agenda now sizes one shared time column from rendered AM, PM, and all-day labels, so event titles remain aligned for formats such as h:mm AP.

Also documents the setting and adds manifest regression coverage.

Validation:
- 106 Python tests pass
- Node model test passes
- manifest.json and shell.json parse successfully
- live Omarchy shell restart and visual verification pass