### PR TITLE
fix: close() no longer aborts on read-only bar facade property

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -246,11 +246,11 @@ Panel {
   }
 
   function close() {
-    setCenterHoverRevealSuppressed(false)
-    // Dismissing the panel mid-edit would otherwise leave the inputs up,
-    // waiting behind a closed popup for the next time it opens.
+    // Hide the panel first: this is the critical operation and must not be
+    // skipped if the cosmetic hover-reveal call below ever throws.
     if (root.editingLife) root.cancelEditingLife()
     root.controller.hide()
+    setCenterHoverRevealSuppressed(false)
   }
 
   function toggle() {
@@ -266,9 +266,14 @@ Panel {
 
   // Summoning by hotkey moves no pointer, so a hover the bar was still
   // holding must not keep the center indicators revealed behind the panel.
+  // The bar exposes a writable method on the plugin facade; on older bars that
+  // predate the facade the property was writable directly. Prefer the method.
   function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && "centerHoverRevealSuppressed" in root.bar)
+    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function") {
+      root.bar.setCenterHoverRevealSuppressed(value)
+    } else if (root.bar && "centerHoverRevealSuppressed" in root.bar) {
       root.bar.centerHoverRevealSuppressed = value
+    }
   }
 
   function refresh() {


### PR DESCRIPTION
## Summary

Fixes a regression where the calendar panel opens but **cannot be closed** and the **keyboard is left locked** (Escape and outside clicks do nothing) after an Omarchy update that handed third-party widgets a read-only `PluginBarApi` facade.

## Root cause

Omarchy changed the value injected into third-party widgets from the raw `bar` object to a read-only `PluginBarApi` facade. On that facade `centerHoverRevealSuppressed` is a **read-only** property (exposed alongside a setter `setCenterHoverRevealSuppressed()`).

`Panel.qml` assigned it directly:

```js
function close() {
  setCenterHoverRevealSuppressed(false)      // <-- throws TypeError now
  ...
  root.controller.hide()                     // <-- never reached
}
```

`setCenterHoverRevealSuppressed()` did `root.bar.centerHoverRevealSuppressed = value`, which throws `TypeError: Cannot assign to read-only property "centerHoverRevealSuppressed"`. Because that call is the **first line** of `close()`, the exception aborts the function before `root.controller.hide()` runs. The panel's `opened` never flips false, so the layer-shell `KeyboardPanel` keeps its keyboard focus grab → the panel stays open and the keyboard is locked. Every Escape press just re-throws (repeated WARN lines in the journal).

## Changes

1. **`setCenterHoverRevealSuppressed()`** now calls `bar.setCenterHoverRevealSuppressed(value)` when the method is available (the new facade), falling back to the writable property for older bars.
2. **`close()`** now hides the panel first, then applies the cosmetic hover-reveal suppression. The critical `controller.hide()` can no longer be skipped by a throw in the cosmetic path.

## Testing

- After the change the journal no longer logs `Cannot assign to read-only property` on open/close.
- The panel opens and closes normally with Escape and with an outside click.
