### PR TITLE
Close the panel through the bar's setter, not a readonly property

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -246,11 +246,14 @@ Panel {
   }
 
   function close() {
+    // Put the panel away before anything else. The popup is a full-screen
+    // overlay holding keyboard focus, so a throw anywhere above this line
+    // leaves the desktop with no way to take a key or a click back.
+    root.controller.hide()
     setCenterHoverRevealSuppressed(false)
     // Dismissing the panel mid-edit would otherwise leave the inputs up,
     // waiting behind a closed popup for the next time it opens.
     if (root.editingLife) root.cancelEditingLife()
-    root.controller.hide()
   }
 
   function toggle() {
@@ -267,7 +270,9 @@ Panel {
   // Summoning by hotkey moves no pointer, so a hover the bar was still
   // holding must not keep the center indicators revealed behind the panel.
   function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && "centerHoverRevealSuppressed" in root.bar)
+    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
+      root.bar.setCenterHoverRevealSuppressed(value)
+    else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
       root.bar.centerHoverRevealSuppressed = value
   }
 


### PR DESCRIPTION
## The bug

Opening the calendar made the desktop unresponsive. Escape did nothing, clicking outside did nothing, and even `SUPER+Enter` looked dead: the terminal did launch, but behind the panel's full-screen overlay and with no way to reach the keyboard. A reboot was the only way out.

## The cause

Recent omarchy (first seen on `4.0.0.r2083`) moved plugins behind `PluginBarApi`, where `centerHoverRevealSuppressed` is `readonly` and `setCenterHoverRevealSuppressed()` takes its place. `close()` still assigned to the property directly:

```
TypeError: Cannot assign to read-only property "centerHoverRevealSuppressed"
```

The throw happened on the first line of `close()`, so `controller.hide()` was never reached and the panel never went away. `KeyboardPanel` is a full-screen layer-shell surface on the overlay layer that holds keyboard focus while open, and escape, outside clicks and the IPC `close` all route through this one function, so nothing could dismiss it.

## The fix

- Prefer `bar.setCenterHoverRevealSuppressed()`, falling back to the direct assignment for shells that predate it. Same idiom as the upstream clock and weather panels.
- Hide the panel first in `close()`, so no later throw can lock the desktop again.

## Testing

Diagnosed from the `TypeError` in the shell journal and read against the current
`PluginBarApi`, `Panel` and `KeyboardPanel` sources. `qmllint` is clean. Holding the
merge until the panel is confirmed dismissable by escape, by an outside click and by
the bar label on `4.0.0.r2083`.
