### PR TITLE
Render event text as plain text, store events owner-only, and harden gws path resolution

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -588,6 +588,7 @@ Panel {
                   anchors.verticalCenter: parent.verticalCenter
                   width: parent.width - Style.space(70)
                   text: root.upcomingEvent ? root.upcomingEvent.title : qsTr("Nothing else today")
+                  textFormat: Text.PlainText
                   color: root.upcomingEvent
                     ? root.contentForeground
                     : Qt.darker(root.contentForeground, 1.9)
@@ -1164,6 +1165,7 @@ Panel {
                   Text {
                     width: parent.width
                     text: eventRow.modelData.title
+                    textFormat: Text.PlainText
                     color: eventRow.declined
                       ? Qt.darker(root.contentForeground, 2.0)
                       : root.contentForeground
@@ -1181,6 +1183,7 @@ Panel {
                       if (Model.isOutOfOffice(eventRow.modelData)) return qsTr("Out of office")
                       return eventRow.modelData.location
                     }
+                    textFormat: Text.PlainText
                     color: Qt.darker(root.contentForeground, 1.9)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption

--- a/sync/omarchy_calendar_sync/cli.py
+++ b/sync/omarchy_calendar_sync/cli.py
@@ -31,6 +31,7 @@ def write_atomic(path, doc):
             stream.flush()
             os.fsync(stream.fileno())
         os.replace(temp_name, path)
+        os.chmod(path, 0o600)
     except BaseException:
         Path(temp_name).unlink(missing_ok=True)
         raise

--- a/sync/omarchy_calendar_sync/gws.py
+++ b/sync/omarchy_calendar_sync/gws.py
@@ -61,10 +61,18 @@ class Gws:
         return code, stdout, stderr
 
     def version(self):
-        _, stdout, _ = self._run(["--version"])
+        code, stdout, stderr = self._run(["--version"])
+        if code != 0:
+            detail = (stderr or stdout or "").strip()
+            raise GwsApiError(
+                f"gws --version exited {code}"
+                + (f": {detail}" if detail else "")
+            )
         match = _VERSION.search(stdout)
         if not match:
-            raise GwsApiError(f"cannot parse gws version from {stdout!r}")
+            raise GwsApiError(
+                f"cannot parse gws version from {stdout!r} (stderr={stderr!r})"
+            )
         return tuple(int(part) for part in match.groups())
 
     def check(self):

--- a/sync/setup
+++ b/sync/setup
@@ -236,7 +236,24 @@ if count == 0:
 
 step "Recording where gws and your credentials live"
 # The timer runs without your shell PATH, so the bare name is not enough.
+# mise shims are absolute paths that still need node/mise on PATH; record the
+# shim (or a real binary if mise can resolve one) and keep mise shims in the
+# unit PATH so systemd can exec it.
 gws_path=$(command -v gws)
+if command -v mise >/dev/null 2>&1; then
+  real=$(mise which gws 2>/dev/null || true)
+  if [ -n "$real" ] && [ -x "$real" ]; then
+    gws_path=$real
+  fi
+fi
+if [ -z "$gws_path" ] || [ ! -x "$gws_path" ]; then
+  echo "  gws is not an executable path: ${gws_path:-empty}"
+  exit 1
+fi
+if ! env -i HOME="$HOME" PATH="$(dirname "$gws_path"):$HOME/.local/share/mise/shims:/usr/bin:/bin" "$gws_path" --version >/dev/null 2>&1; then
+  echo "  warning: gws --version failed under a systemd-like PATH."
+  echo "  recorded path: $gws_path"
+fi
 config="$HOME/.config/omarchy/calendar-sync.json"
 mkdir -p "$(dirname "$config")"
 python3 - "$config" "$gws_path" "$PROFILE" <<'PYEOF'

--- a/sync/systemd/omarchy-calendar-sync.service
+++ b/sync/systemd/omarchy-calendar-sync.service
@@ -8,7 +8,7 @@ Type=oneshot
 # A user service starts with a minimal PATH, so a gws installed by bun,
 # cargo or pipx would be invisible. sync/setup writes an absolute path
 # into calendar-sync.json; this list is the fallback for everyone else.
-Environment=PATH=%h/.local/bin:%h/.cache/.bun/bin:%h/.bun/bin:%h/.cargo/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=%h/.local/share/mise/shims:%h/.local/bin:%h/.cache/.bun/bin:%h/.bun/bin:%h/.cargo/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=%h/.config/omarchy/plugins/tmn73.calendar/sync/omarchy-calendar-sync
 # A failed run is deliberately allowed to surface as a failed unit. The
 # sync leaves the previous events file intact either way, and a user

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,12 @@ class TestWriteAtomic(unittest.TestCase):
             cli.write_atomic(path, {"hello": "world"})
             self.assertEqual([p.name for p in Path(tmp).iterdir()], ["out.json"])
 
+    def test_events_file_is_owner_readable_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "out.json"
+            cli.write_atomic(path, {"hello": "world"})
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+
 
 class TestRun(unittest.TestCase):
     def test_writes_a_valid_document(self):

--- a/tests/test_gws.py
+++ b/tests/test_gws.py
@@ -49,6 +49,16 @@ class TestVersion(unittest.TestCase):
         client = gws.Gws("/tmp/profile", runner=FakeRunner({"--version": (0, "gws 0.13.2\nnote\n", "")}))
         self.assertEqual(client.version(), (0, 13, 2))
 
+    def test_version_nonzero_exit_surfaces_stderr(self):
+        client = gws.Gws(
+            "/tmp/profile",
+            runner=FakeRunner({"--version": (127, "", "exec: node: not found")}),
+        )
+        with self.assertRaises(gws.GwsApiError) as raised:
+            client.version()
+        self.assertIn("exited 127", str(raised.exception))
+        self.assertIn("node: not found", str(raised.exception))
+
     def test_missing_binary_raises(self):
         def runner(argv, env):
             raise FileNotFoundError("gws")


### PR DESCRIPTION
Two independent changes, in separate commits:

**security: render event title/location as plain text and store events JSON owner-only**
- `Text.PlainText` on title and location in Panel.qml, so an event name or venue cannot make Qt fetch remote HTML from inside the shell panel.
- `write_atomic` now `chmod 600`s the events file, so OAuth-derived calendar data isn't world-readable.

**fix: surface gws version failures and resolve the sync binary via mise**
- `gws --version` is checked for a non-zero exit and surfaces exit code + stderr, instead of silently parsing empty output (the mise "node not found" case).
- `sync/setup` resolves gws through mise when present and warns when `--version` fails under a systemd-like PATH; the unit PATH now includes mise shims.

New unit tests included. Full suite: 106 tests pass.