### PR TITLE
Render event titles and locations as plain text

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -587,6 +587,10 @@ Panel {
                 Text {
                   anchors.verticalCenter: parent.verticalCenter
                   width: parent.width - Style.space(70)
+                  // Supplied by whoever sent the invitation, so never rich
+                  // text: Qt's default AutoText parses markup out of a summary
+                  // and fetches any resource it names.
+                  textFormat: Text.PlainText
                   text: root.upcomingEvent ? root.upcomingEvent.title : qsTr("Nothing else today")
                   color: root.upcomingEvent
                     ? root.contentForeground
@@ -1163,6 +1167,7 @@ Panel {
 
                   Text {
                     width: parent.width
+                    textFormat: Text.PlainText
                     text: eventRow.modelData.title
                     color: eventRow.declined
                       ? Qt.darker(root.contentForeground, 2.0)
@@ -1176,6 +1181,7 @@ Panel {
                   Text {
                     width: parent.width
                     visible: text !== ""
+                    textFormat: Text.PlainText
                     text: {
                       if (eventRow.declined) return qsTr("Declined")
                       if (Model.isOutOfOffice(eventRow.modelData)) return qsTr("Out of office")


### PR DESCRIPTION
Closes #16.

The three `Text` elements showing calendar-derived strings set no `textFormat`, so Qt applies `AutoText`: anything resembling markup is parsed as rich text, and Qt's rich-text engine loads the resources it references.

Those strings come from whoever sent the invitation. That makes an event summary an attacker-chosen outbound request from the viewer's machine — a tracking pixel that also reports when the panel is open — plus a formatting surprise in an otherwise uniform list.

**Reproduced** on Qt 6.11.2, matching the report in #16: a summary containing `<img src="http://127.0.0.1:8099/pixel.png">` fetches the URL under `AutoText` and does nothing under `PlainText`.

The built-in Omarchy clock panel this widget was forked from is explicit about `PlainText` in eight places; these three lost it on the way across.

**Scope.** #14 carried this fix alongside two unrelated changes and was closed. This is only the `textFormat` part — three lines, no behaviour change for well-formed events.

Found while running this widget against several shared calendars, where every title on screen is written by someone else.