### PR TITLE
Fade secondary text toward the background so light themes keep their hierarchy

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -226,6 +226,19 @@ Panel {
   readonly property color contentForeground: bar ? bar.foreground : Color.foreground
   readonly property string contentFontFamily: bar ? bar.fontFamily : Style.font.family
 
+  // De-emphasis that survives a light theme. Qt.darker on the foreground only
+  // reads as "quieter" while the background is darker than the text; against a
+  // light background it raises contrast instead, so on a light theme every
+  // receding element here stopped receding -- week numbers, weekday headings,
+  // the month label, out-of-month days, weekends and declined invitations all
+  // came forward rather than back. Fading the foreground toward whatever sits
+  // behind it is the one form that works in both directions.
+  //
+  // `amount` is an opacity: 1.0 is the plain foreground, lower is quieter.
+  function quiet(amount) {
+    return Qt.rgba(contentForeground.r, contentForeground.g, contentForeground.b, amount)
+  }
+
   readonly property int cellWidth: Style.space(52)
   readonly property int cellHeight: Style.space(34)
   readonly property int cellSpacing: Style.space(2)
@@ -590,7 +603,7 @@ Panel {
                   text: root.upcomingEvent ? root.upcomingEvent.title : qsTr("Nothing else today")
                   color: root.upcomingEvent
                     ? root.contentForeground
-                    : Qt.darker(root.contentForeground, 1.9)
+                    : root.quiet(0.50)
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
                   elide: Text.ElideRight
@@ -599,7 +612,7 @@ Panel {
                 Text {
                   anchors.verticalCenter: parent.verticalCenter
                   text: root.upcomingCountdown
-                  color: Qt.darker(root.contentForeground, 1.4)
+                  color: root.quiet(0.72)
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
                 }
@@ -614,7 +627,7 @@ Panel {
                 Text {
                   anchors.verticalCenter: parent.verticalCenter
                   text: "BORN"
-                  color: Qt.darker(root.contentForeground, 1.5)
+                  color: root.quiet(0.68)
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
                   font.letterSpacing: 1
@@ -637,7 +650,7 @@ Panel {
                   anchors.verticalCenterOffset: 0
                   leftPadding: Style.space(6)
                   text: "LIVE TO"
-                  color: Qt.darker(root.contentForeground, 1.5)
+                  color: root.quiet(0.68)
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
                   font.letterSpacing: 1
@@ -662,7 +675,7 @@ Panel {
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
                 text: root.today.getFullYear()
-                color: Qt.darker(root.contentForeground, 1.5)
+                color: root.quiet(0.68)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.bodySmall
                 font.letterSpacing: 1
@@ -722,7 +735,7 @@ Panel {
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
                 text: "LIFE"
-                color: Qt.darker(root.contentForeground, 1.5)
+                color: root.quiet(0.68)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.bodySmall
                 font.letterSpacing: 1
@@ -823,7 +836,7 @@ Panel {
                     text: "W"
                     color: weekStartMouse.containsMouse
                       ? Style.hoverStateColor(root.contentForeground, Color.accent)
-                      : Qt.darker(root.contentForeground, 1.9)
+                      : root.quiet(0.50)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
                     font.letterSpacing: 1
@@ -860,7 +873,7 @@ Panel {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     text: root.weekdayLabel(modelData)
-                    color: Qt.darker(root.contentForeground, 1.5)
+                    color: root.quiet(0.68)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
                     font.letterSpacing: 1
@@ -882,7 +895,7 @@ Panel {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     text: modelData.week
-                    color: Qt.darker(root.contentForeground, 1.9)
+                    color: root.quiet(0.50)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
                   }
@@ -922,8 +935,8 @@ Panel {
                         anchors.verticalCenterOffset: modelData.hasEvent ? -Style.space(3) : 0
                         text: modelData.day
                         color: modelData.inMonth
-                          ? (modelData.weekend ? Qt.darker(root.contentForeground, 1.45) : root.contentForeground)
-                          : Qt.darker(root.contentForeground, 2.2)
+                          ? (modelData.weekend ? root.quiet(0.70) : root.contentForeground)
+                          : root.quiet(0.40)
                         font.family: root.contentFontFamily
                         font.pixelSize: Style.font.body
                         font.bold: modelData.today
@@ -997,7 +1010,7 @@ Panel {
                 width: Style.space(130)
                 horizontalAlignment: Text.AlignHCenter
                 text: Qt.formatDate(root.viewDate, "MMMM yyyy").toUpperCase()
-                color: Qt.darker(root.contentForeground, 1.4)
+                color: root.quiet(0.72)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body
                 font.letterSpacing: 1
@@ -1041,7 +1054,7 @@ Panel {
             Text {
               width: parent.width
               text: Qt.formatDate(root.selectedDate, "dddd d MMMM").toUpperCase()
-              color: Qt.darker(root.contentForeground, 1.4)
+              color: root.quiet(0.72)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.caption
               font.letterSpacing: 1
@@ -1095,7 +1108,7 @@ Panel {
                   border.width: Style.spacing.hairline
                   border.color: joinHover.hovered
                     ? "transparent"
-                    : Qt.darker(root.contentForeground, 2.0)
+                    : root.quiet(0.46)
 
                   HoverHandler {
                     id: joinHover
@@ -1113,7 +1126,7 @@ Panel {
                     id: joinLabel
                     anchors.centerIn: parent
                     text: qsTr("Join")
-                    color: joinHover.hovered ? Color.background : Qt.darker(root.contentForeground, 1.4)
+                    color: joinHover.hovered ? Color.background : root.quiet(0.72)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
                   }
@@ -1150,7 +1163,7 @@ Panel {
                   text: eventRow.modelData.allDay
                     ? qsTr("All day")
                     : Qt.formatDateTime(new Date(eventRow.modelData.start), "HH:mm")
-                  color: Qt.darker(root.contentForeground, eventRow.declined ? 2.2 : 1.5)
+                  color: root.quiet(eventRow.declined ? 0.40 : 0.68)
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
                   font.strikeout: eventRow.declined
@@ -1165,7 +1178,7 @@ Panel {
                     width: parent.width
                     text: eventRow.modelData.title
                     color: eventRow.declined
-                      ? Qt.darker(root.contentForeground, 2.0)
+                      ? root.quiet(0.46)
                       : root.contentForeground
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.bodySmall
@@ -1181,7 +1194,7 @@ Panel {
                       if (Model.isOutOfOffice(eventRow.modelData)) return qsTr("Out of office")
                       return eventRow.modelData.location
                     }
-                    color: Qt.darker(root.contentForeground, 1.9)
+                    color: root.quiet(0.50)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
                     elide: Text.ElideRight
@@ -1199,7 +1212,7 @@ Panel {
               visible: root.selectedEvents.length === 0
               color: root.syncState === "missing" && emptyHover.hovered
                 ? Style.hoverStateColor(root.contentForeground, Color.accent)
-                : Qt.darker(root.contentForeground, 1.9)
+                : root.quiet(0.50)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.caption
               wrapMode: Text.WordWrap


### PR DESCRIPTION
On a light theme the panel's whole secondary-text hierarchy inverts.

`Qt.darker` on the foreground only reads as de-emphasis while the background is *darker* than the text. Against a light background it raises contrast instead. With Omarchy's Aether theme (`mode = "light"`, `#212121` text on `#fafafa`) every receding element stops receding: week numbers, weekday headings, the month label, out-of-month days, weekends, and declined invitations all come **forward** rather than back — leaving the strikeout as the only thing still marking a declined invite as declined.

**The change.** A `quiet(amount)` helper returns the foreground at a given opacity, which recedes in both directions:

```qml
function quiet(amount) {
  return Qt.rgba(contentForeground.r, contentForeground.g, contentForeground.b, amount)
}
```

All 18 `Qt.darker(root.contentForeground, N)` call sites move to it, with the factors mapped one for one so **the dark-theme appearance is unchanged**:

| was | becomes |
|---|---|
| 1.4 | 0.72 |
| 1.45 | 0.70 |
| 1.5 | 0.68 |
| 1.9 | 0.50 |
| 2.0 | 0.46 |
| 2.2 | 0.40 |

`Qt.darker(modelData.color, 2.2)` on the declined colour bar is left alone — that is a saturated calendar colour, not the theme foreground, and darkening reads correctly either way.

No behaviour change, no new settings; `tests/model.test.js` still passes (65/65).