### PR TITLE
Keep all-day events whose end date is not after their start

### DIFF
--- a/sync/omarchy_calendar_sync/normalize.py
+++ b/sync/omarchy_calendar_sync/normalize.py
@@ -83,13 +83,17 @@ def normalize_event(gevent, calendar, tz):
     except (KeyError, ValueError, TypeError):
         return []
 
-    if all_day:
-        # Google's all-day end.date must be strictly after start.date.
-        if end_dt.date() <= start_dt.date():
-            return []
-    elif end_dt < start_dt:
-        # A zero-length timed event (end == start) is a legal marker.
+    if not all_day and end_dt < start_dt:
+        # A zero-length timed event (end == start) is a legal marker; one that
+        # ends before it begins is not.
         return []
+
+    # An all-day end.date is documented as exclusive and strictly after the
+    # start, but the API does hand back events that break that -- a one-day
+    # marker can arrive as start 2026-10-02, end 2026-10-02. Dropping those
+    # hid an event the user can see in Google Calendar, with nothing logged.
+    # _covered_days already clamps `last` up to `first`, which yields exactly
+    # the one day such an event occupies.
 
     title = (gevent.get("summary") or "").strip() or NO_TITLE
     location = gevent.get("location") or ""

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -112,13 +112,17 @@ class TestAllDayEvents(unittest.TestCase):
             [r["dateKey"] for r in rows], ["2026-08-17", "2026-08-18", "2026-08-19"]
         )
 
-    def test_end_date_equal_to_start_date_produces_no_rows(self):
+    def test_end_date_equal_to_start_date_still_occupies_its_day(self):
+        # Not what the API documents, but what it returns for some one-day
+        # markers. The event is visible in Google Calendar, so hiding it here
+        # would be a silent disagreement with what the user can see.
         rows = normalize.normalize_event(all_day("2026-08-17", "2026-08-17"), CAL, BOGOTA)
-        self.assertEqual(rows, [])
+        self.assertEqual([r["dateKey"] for r in rows], ["2026-08-17"])
+        self.assertTrue(rows[0]["allDay"])
 
-    def test_end_date_before_start_date_produces_no_rows(self):
+    def test_end_date_before_start_date_still_occupies_its_start(self):
         rows = normalize.normalize_event(all_day("2026-08-17", "2026-08-16"), CAL, BOGOTA)
-        self.assertEqual(rows, [])
+        self.assertEqual([r["dateKey"] for r in rows], ["2026-08-17"])
 
 
 class TestFiltering(unittest.TestCase):


### PR DESCRIPTION
An event that is plainly visible in Google Calendar never reaches the widget, and nothing is logged to say why.

`normalize_event` drops any all-day event whose `end.date` is not strictly after `start.date`:

```python
if all_day:
    # Google's all-day end.date must be strictly after start.date.
    if end_dt.date() <= start_dt.date():
        return []
```

That rule is what Google documents, but not what the API always returns. On my own calendar a one-day marker comes back as:

```json
{"summary": "返回日本", "start": {"date": "2026-10-02"}, "end": {"date": "2026-10-02"}}
```

It renders normally in Google Calendar and is simply absent from the bar. I only found it by diffing this sync against another reader of the same account — the widget gives no sign that anything was skipped.

**The change.** `_covered_days` already ends with:

```python
if last < first:
    last = first
```

which yields exactly the one day such an event occupies. The guard above was the only thing stopping execution reaching it. Removing it lets the clamp do the work; an event that ends *before* it starts now lands on its start date rather than vanishing. The zero-length **timed** marker case is untouched.

**Tests.** The two cases that pinned the old behaviour now assert the new one, with a comment on why. Full suite passes (104/104).

I appreciate the old behaviour was deliberate — the guard has a comment and tests. The argument for changing it is that the alternative to showing a malformed event is silently disagreeing with what the user sees in Google Calendar, and the malformation is harmless once the clamp handles it. Happy to take this in a different direction if you would rather log and skip.